### PR TITLE
Fix the 'libpam required but missing' issue when cross-compile for ARM

### DIFF
--- a/generic/build.vars
+++ b/generic/build.vars
@@ -39,6 +39,6 @@ fi
 EXTRA_OPENSSL_CONFIG="${EXTRA_OPENSSL_CONFIG:--static-libgcc}" # uncomment if openvpn.exe fails to start with missing libgcc_s_sjlj-1.dll (win32)
 #EXTRA_LZO_CONFIG
 #EXTRA_PKCS11_HELPER_CONFIG
-EXTRA_OPENVPN_CONFIG="${EXTRA_OPENVPN_CONFIG:---enable-password-save --disable-debug --disable-snappy}"
+EXTRA_OPENVPN_CONFIG="${EXTRA_OPENVPN_CONFIG:---enable-password-save --disable-debug --disable-snappy --disable-plugin-auth-pam}"
 
 TARGET_ROOT="${TARGET_ROOT:-/}"


### PR DESCRIPTION
The is a problem when using the openvpn-build to cross-compile for arm platform on Ubuntu 14.
after fired the command
IMAGEROOT=`pwd`/image-arm CHOST=arm-linux-gnueabi CBUILD=x86_64-pc-linux-gnu ./build

the error 'libpam required but missing' will shows up.
This is because there is NO libpam library in the cross-compile environment.

Considering the libpam is not common used(I suppose). I disabled it in the default options.

Cheers,
Billy YAO