### PR TITLE
Add make to cygwin packages

### DIFF
--- a/generic/README
+++ b/generic/README
@@ -28,6 +28,7 @@ Cross compile
 			Packages:
 				diffutils
 				m4
+				make
 				mingw64-i686-binutils
 				mingw64-i686-gcc-core
 				mingw64-i686-headers


### PR DESCRIPTION
Just did a fresh build by following step-by-step openvpn-build instructions, compiled on win 64 via cygwin.
Got the simple error that make wasn't installed.