### PR TITLE
remove obsolete configure options

### DIFF
--- a/generic/build.vars
+++ b/generic/build.vars
@@ -39,6 +39,6 @@ fi
 EXTRA_OPENSSL_CONFIG="${EXTRA_OPENSSL_CONFIG:--static-libgcc}" # uncomment if openvpn.exe fails to start with missing libgcc_s_sjlj-1.dll (win32)
 #EXTRA_LZO_CONFIG
 #EXTRA_PKCS11_HELPER_CONFIG
-EXTRA_OPENVPN_CONFIG="${EXTRA_OPENVPN_CONFIG:---enable-password-save --disable-snappy}"
+#EXTRA_OPENVPN_CONFIG
 
 TARGET_ROOT="${TARGET_ROOT:-/}"


### PR DESCRIPTION
--enable-password-save --disable-snappy are not supported in openvpn-2.3.10