### PR TITLE
Add installation of openvpnserv2.exe to Windows installers

### DIFF
--- a/windows-nsis/build
+++ b/windows-nsis/build
@@ -93,6 +93,7 @@ main() {
 		-DOPENVPN_ROOT="$(dospath "${OPENVPN_ROOT}")" \
 		-DTAP_WINDOWS_INSTALLER="$(dospath "${TAP_WINDOWS_INSTALLER}")" \
 		${TAP_WINDOWS_INSTALLER:+-DUSE_TAP_WINDOWS} \
+		-DOPENVPNSERV2_EXECUTABLE="$(dospath "${OPENVPNSERV2_EXECUTABLE}")" \
 		-DEASYRSA_ROOT="$(dospath "${EASYRSA_ROOT}")" \
 		${EASYRSA_TARBALL:+-DUSE_EASYRSA} \
 		-DUSE_OPENVPN_GUI \
@@ -124,6 +125,9 @@ while [ -n "$1" ]; do
 		--tap-windows=*)
 			TAP_WINDOWS_INSTALLER="${v}"
 			;;
+		--openvpnserv2=*)
+			OPENVPNSERV2_EXECUTABLE="${v}"
+			;;
 		--sign)
 			DO_SIGN=1
 			;;
@@ -150,6 +154,7 @@ Usage: $0
 	--openvpn-bin-tarball=tarball	openvpn binary tarball
 	--easy-rsa-tarball=tarball	easy-rsa source tarball
 	--tap-windows=installer         tap-windows installer
+	--openvpnserv2=executable	openvpnserv2 executable
 	--sign				do sign
 	--sign-digest=digest		specify signing digest (default: sha256)
 	--sign-pkcs12=pkcs12-file	signing PKCS#12 file
@@ -165,6 +170,7 @@ done
 
 [ -n "${OPENVPN_TARBALL}" ] || die "please specify openvpn binary tarball"
 [ -f "${OPENVPN_TARBALL}" ] || die "cannot find openvpn binary tarball '${OPENVPN_TARBALL}'"
+[ -f "${OPENVPNSERV2_EXECUTABLE}" ] || die "cannot find openvpnserv2 executable '${OPENVPNSERV2_EXECUTABLE}'"
 if [ -n "${EASYRSA_TARBALL}" ]; then
 	[ -f "${EASYRSA_TARBALL}" ] || die "cannot find easy-rsa tarball '${EASYRSA_TARBALL}'"
 fi

--- a/windows-nsis/build-complete
+++ b/windows-nsis/build-complete
@@ -11,6 +11,7 @@ main() {
 
 	"${WGET}" ${WGET_OPTS} --directory-prefix=${TMPDIR} "${EASY_RSA_URL}" || die "get easy-rsa"
 	"${WGET}" ${WGET_OPTS} --directory-prefix=${TMPDIR} "${TAP_WINDOWS_INSTALLER_URL}" || die "get tap-windows"
+	"${WGET}" ${WGET_OPTS} --directory-prefix=${TMPDIR} "${OPENVPNSERV2_URL}" || die "get openvpnserv2"
 
 	for arch in i686 x86_64; do
 		echo "BUILDING ${arch}"
@@ -35,6 +36,7 @@ main() {
 			--openvpn-bin-tarball=$(ls ${TMPDIR}/image-${arch}/openvpn-${arch}-*-bin.*) \
 			--easy-rsa-tarball=$(ls ${TMPDIR}/easy-rsa-*) \
 			--tap-windows=$(ls ${TMPDIR}/tap-windows-*) \
+			--openvpnserv2=$(ls ${TMPDIR}/openvpnserv2*) \
 			--output-dir="${OUTPUT_DIR}" \
 			${DO_SIGN:+--sign} \
 			--sign-pkcs12="${SIGN_PKCS12}" \

--- a/windows-nsis/build-complete.vars
+++ b/windows-nsis/build-complete.vars
@@ -3,9 +3,11 @@ INSTALLER_VERSION="601"
 
 EASY_RSA_VERSION="${EASY_RSA_VERSION:-2.2.0_master}"
 TAP_WINDOWS_INSTALLER_VERSION="${TAP_WINDOWS_INSTALLER_VERSION:-9.21.2}"
+OPENVPNSERV2_VERSION="${OPENVPNSERV2_VERSION:-1.0.0.0}"
 
 EASY_RSA_URL="${EASY_RSA_URL:-http://build.openvpn.net/downloads/releases/easy-rsa-${EASY_RSA_VERSION}.tar.gz}"
 TAP_WINDOWS_INSTALLER_URL="${TAP_WINDOWS_INSTALLER_URL:-http://build.openvpn.net/downloads/releases/tap-windows-${TAP_WINDOWS_INSTALLER_VERSION}.exe}"
+OPENVPNSERV2_URL="${OPENVPNSERV2_URL:-http://build.openvpn.net/downloads/releases/openvpnserv2-${OPENVPNSERV2_VERSION}.exe}"
 
 WGET="${WGET:-wget}"
 

--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -250,6 +250,7 @@ Section /o "${PACKAGE_NAME} Service" SecService
 	SetOverwrite on
 
 	SetOutPath "$INSTDIR\bin"
+	File /oname=openvpnserv2.exe "${OPENVPNSERV2_EXECUTABLE}"
 	File "${OPENVPN_ROOT}\bin\openvpnserv.exe"
 
 	SetOutPath "$INSTDIR\config"
@@ -589,6 +590,7 @@ Section "Uninstall"
 
 	Delete "$INSTDIR\bin\openvpn.exe"
 	Delete "$INSTDIR\bin\openvpnserv.exe"
+	Delete "$INSTDIR\bin\openvpnserv2.exe"
 	Delete "$INSTDIR\bin\libeay32.dll"
 	Delete "$INSTDIR\bin\ssleay32.dll"
 	Delete "$INSTDIR\bin\liblzo2-2.dll"


### PR DESCRIPTION
This PR ensures that the Windows installer installs openvpnserv2.exe alongside openvpnserv.exe. Registering openvpnserv2.exe a Windows service is not implemented yet, because registration fucntionality [is missing](https://github.com/xkjyeah/openvpnserv2/issues/4) from openvpnserv2.

v2: Remove openvpnserv2.exe on uninstall

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>