### PR TITLE
fix build in case no wget is installed (using curl)

### DIFF
--- a/generic/build
+++ b/generic/build
@@ -365,8 +365,8 @@ solaris_common() {
 main() {
 	export CFLAGS="${TARGET_CFLAGS} ${EXTRA_TARGET_CFLAGS}"
 	export LDFLAGS="${TARGET_LDFLAGS} ${EXTRA_TARGET_LDFLAGS}"
-	download
 	create_layout
+	download
 	extract
 	build_dep
 	if [ -z "${DO_ONLY_DEPS}" ]; then

--- a/generic/build.vars
+++ b/generic/build.vars
@@ -8,7 +8,7 @@ TAP_WINDOWS_VERSION="${TAP_WINDOWS_VERSION:-9.21.2}"
 OPENVPN_VERSION="${OPENVPN_VERSION:-2.3.11}"
 OPENVPN_GUI_VERSION="${OPENVPN_GUI_VERSION:-10}"
 
-OPENSSL_URL="${OPENSSL_URL:-http://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz}"
+OPENSSL_URL="${OPENSSL_URL:-https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz}"
 PKCS11_HELPER_URL="${PKCS11_HELPER_URL:-http://downloads.sourceforge.net/project/opensc/pkcs11-helper/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.bz2}"
 TAP_WINDOWS_URL="${TAP_WINDOWS_URL:-http://build.openvpn.net/downloads/releases/tap-windows-${TAP_WINDOWS_VERSION}.zip}"
 LZO_URL="${LZO_URL:-http://www.oberhumer.com/opensource/lzo/download/lzo-${LZO_VERSION}.tar.gz}"
@@ -27,7 +27,7 @@ CURL="${CURL:-curl}"
 MAKE="${MAKE:-make}"
 
 #WGET_OPTS
-CURL_OPTS="${CURL_OPTS:---progress-bar --verbose --remote-name}"
+CURL_OPTS="${CURL_OPTS:---progress-bar --verbose --remote-name -L}"
 MAKEOPTS="${MAKEOPTS:--j3}"
 #DO_NO_STRIP
 #DO_STATIC=


### PR DESCRIPTION
```
R00-2+jenkins@r00-2 ~/openvpn-build/generic
$  IMAGEROOT=`pwd`/image-win32 CHOST=i686-w64-mingw32 CBUILD=i686-pc-cygwin ./build
./build: line 77: cd: /home/jenkins/openvpn-build/generic/sources: No such file or directory
FATAL: Cannot download http://www.oberhumer.com/opensource/lzo/download/lzo-2.09.tar.gz

R00-2+jenkins@r00-2 ~/openvpn-build/generic
$
```