### PR TITLE
travis-ci: we need wait for 16.04 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ matrix:
       env: SCRIPT=windows-nsis/build-snapshot
     - compiler: ": complete"
       env: SCRIPT=windows-nsis/build-complete
-
   exclude:
     - compiler: gcc
+  allow_failures:
+    - compiler: ": snapshot"
+      env: SCRIPT=windows-nsis/build-snapshot
 
 before_script:
     - unset CC; unset CXX


### PR DESCRIPTION
mingw 4.8 is not usable for compiling Vista things like firewall
I commented snapshot build for a while (I was not lucky in installing 4.9 on ubuntu 14.04)

let us wait for 16.04 images