### PR TITLE
Use more reasonable build parameters in build.vars

### DIFF
--- a/generic/build.vars
+++ b/generic/build.vars
@@ -1,18 +1,18 @@
 # -*- mode: sh; -*-
 BUILD_VERSION="001"
 
-OPENSSL_VERSION="${OPENSSL_VERSION:-1.0.1t}"
+OPENSSL_VERSION="${OPENSSL_VERSION:-1.0.1u}"
 PKCS11_HELPER_VERSION="${PKCS11_HELPER_VERSION:-1.11}"
 LZO_VERSION="${LZO_VERSION:-2.09}"
 TAP_WINDOWS_VERSION="${TAP_WINDOWS_VERSION:-9.21.2}"
-OPENVPN_VERSION="${OPENVPN_VERSION:-2.3.11}"
-OPENVPN_GUI_VERSION="${OPENVPN_GUI_VERSION:-10}"
+OPENVPN_VERSION="${OPENVPN_VERSION:-2.3_git}"
+OPENVPN_GUI_VERSION="${OPENVPN_GUI_VERSION:-11}"
 
 OPENSSL_URL="${OPENSSL_URL:-https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz}"
 PKCS11_HELPER_URL="${PKCS11_HELPER_URL:-http://downloads.sourceforge.net/project/opensc/pkcs11-helper/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.bz2}"
 TAP_WINDOWS_URL="${TAP_WINDOWS_URL:-http://build.openvpn.net/downloads/releases/tap-windows-${TAP_WINDOWS_VERSION}.zip}"
 LZO_URL="${LZO_URL:-http://www.oberhumer.com/opensource/lzo/download/lzo-${LZO_VERSION}.tar.gz}"
-OPENVPN_URL="${OPENVPN_URL:-http://build.openvpn.net/downloads/releases/openvpn-${OPENVPN_VERSION}.tar.gz}"
+OPENVPN_URL="${OPENVPN_URL:-http://build.openvpn.net/downloads/snapshots/openvpn-${OPENVPN_VERSION}.tar.gz}"
 OPENVPN_GUI_URL="${OPENVPN_GUI_URL:-http://build.openvpn.net/downloads/releases/openvpn-gui-${OPENVPN_GUI_VERSION}.tar.gz}"
 
 #CHOST


### PR DESCRIPTION
Previously the installers generated using "master" branch in openvpn-build would
not work properly. With this change all the components (openvpn, openvpnserv,
openvpn-gui) work in unison. In addition build should work out of the box
without any modifications of build.vars or build-complete.vars.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>