### PR TITLE
Fix wrong OPENVPN_VERSION default in build-snapshot

### DIFF
--- a/windows-nsis/build-snapshot
+++ b/windows-nsis/build-snapshot
@@ -12,7 +12,7 @@ get_full_path() {
 }
 
 GIT="${GIT:-git}"
-OPENVPN_VERSION="${OPENVPN_VERSION:-2.3_git}"; export OPENVPN_VERSION
+OPENVPN_VERSION="${OPENVPN_VERSION:-2.4_alpha2}"; export OPENVPN_VERSION
 OPENVPN_BRANCH="${OPENVPN_BRANCH:-master}"
 OPENVPN_URL="${OPENVPN_URL:-http://github.com/OpenVPN/openvpn.git}"
 


### PR DESCRIPTION
URL: https://github.com/OpenVPN/openvpn-build/issues/39
Signed-off-by: Samuli Seppänen <samuli@openvpn.net>