### PR TITLE
Check bitness in uninstaller for correct Registry view

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -604,7 +604,7 @@ Function un.onInit
 	ClearErrors
 	!insertmacro MULTIUSER_UNINIT
 	SetShellVarContext all
-	${If} "${ARCH}" == "x86_64"
+	${If} ${RunningX64}
 		SetRegView 64
 	${EndIf}
 FunctionEnd


### PR DESCRIPTION
This is required to get the registry keys deleted during uninstall on 64 bit platforms.