### PR TITLE
Simplifiy user choices and always install openvpn, dlls and services

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -264,7 +264,7 @@ Section "${PACKAGE_NAME} User-Space Components" SecOpenVPNUserSpace
 
 SectionEnd
 
-Section "${PACKAGE_NAME} Service" SecService
+Section /o "${PACKAGE_NAME} Service" SecService
 
 	SetOverwrite on
 


### PR DESCRIPTION
As discussed in the IRC meeting of Dec 7 and under Issue 59:

- Install "user-space", dlls, iservice by default
- Service (openvpnserv2), GUI, TAP can be selected/unselected
  (selected by default)
- EasyRSA is optional (unselected by default)
- Add-to-path, add-shortcuts, launch-on-logon and file-asociation
  grouped into advance options (selected by default)
- If Service is not selected, openvpnserv2 is not removed, only stopped

It is now possible to unselect service, GUI, TAP in any combination
and still have a working setup using previously installed versions
of those components. However, lack of an installed version of TAP will
cause services not to startup -- this is not checked or warned against.

All hidden and displayed sections may be selected/unselected from the
command line but consistency of those combinations is not guaranteed.

Signed-off-by: Selva Nair <selva.nair@gmail.com>