### PR TITLE
quick & dirty fix for trac#806

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -205,7 +205,8 @@ Section -pre
 		Pop $R0 # return value/error/timeout
 		DetailPrint "Stopping OpenVPN automatic service (may fail if not found)..."
 		; Only stop now, will be removed in SecService if selected
-		nsExec::ExecToLog '"$SYSDIR\net.exe" stop OpenVPNService /yes'
+		ReadEnvStr $R0 COMSPEC
+		nsExec::ExecToLog '"$R0" /c "$SYSDIR\sc.exe" stop OpenVPNService >nul'
 		Pop $R0 # return value/error/timeout
 
 		Sleep 3000
@@ -276,15 +277,7 @@ Section /o "${PACKAGE_NAME} Service" SecService
 	DetailPrint "Installing OpenVPN Service..."
 
 	DotNetChecker::IsDotNet40FullInstalled
-	Pop $0
-	${If} $0 == "false"
-	${OrIf} $0 == "f" ; could be either false or f as per dotnetchecker.nsh
-		DetailPrint "NET 4.0 not found. Using sc.exe to install openvpnservice"
-		nsExec::ExecToLog '$SYSDIR\sc.exe create OpenVPNService binPath= "$INSTDIR\bin\openvpnserv2.exe" depend= tap0901/dhcp'
-	${Else}
-		DetailPrint "Running openvpnserv2.exe -install"
-		nsExec::ExecToLog '"$INSTDIR\bin\openvpnserv2.exe" -install'
-	${EndIf}
+	nsExec::ExecToLog '$SYSDIR\sc.exe create OpenVPNService binPath= "$INSTDIR\bin\openvpnserv2.exe" depend= tap0901/dhcp'
 
 	Pop $R0 # return value/error/timeout
 


### PR DESCRIPTION
* supress any output when stopping automatic service (either net.exe or sc.exe produces a lot of messages)
* always install openvpnserv2.exe using sc.exe (it produces less output and such way seems to be better because it register dependancy)

in russian windows console utilities (such as net.exe, sc.exe) display output in cp866 (as far as I know, no other language is localized in such strange way), so it is displayed as something scrambled in installer GUI.

this PR does not resolve issue, but it reduces "scrambled" output.