### PR TITLE
Clarify that the certificate management scripts refer to EasyRSA 2

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -112,7 +112,7 @@ LangString DESC_SecOpenVPNGUI ${LANG_ENGLISH} "Install ${PACKAGE_NAME} GUI by Ma
 
 LangString DESC_SecTAP ${LANG_ENGLISH} "Install/upgrade the TAP virtual device driver."
 
-LangString DESC_SecOpenVPNEasyRSA ${LANG_ENGLISH} "Install ${PACKAGE_NAME} RSA scripts for X509 certificate management."
+LangString DESC_SecOpenVPNEasyRSA ${LANG_ENGLISH} "Install EasyRSA 2 scripts for X509 certificate management."
 
 LangString DESC_SecOpenSSLDLLs ${LANG_ENGLISH} "Install OpenSSL DLLs locally (may be omitted if DLLs are already installed globally)."
 
@@ -485,7 +485,7 @@ Section "-OpenSSL Utilities" SecOpenSSLUtilities
 
 SectionEnd
 
-Section /o "${PACKAGE_NAME} RSA Certificate Management Scripts" SecOpenVPNEasyRSA
+Section /o "EasyRSA 2 Certificate Management Scripts" SecOpenVPNEasyRSA
 
 	SetOverwrite on
 	SetOutPath "$INSTDIR\easy-rsa"


### PR DESCRIPTION
From user perspective it was not clear what certificate management scripts the installer provided. Even if the user knew the installer contained EasyRSA, there was no clear indication of whether it was EasyRSA 3 (=easy-rsa on our GitHub page) or EasyRSA 2 (=easy-rsa-old).