### PR TITLE
Add a registry entry for ovpn_admin_group set to its default value

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -405,6 +405,7 @@ Function CoreSetup
 	!insertmacro WriteRegStringIfUndef HKLM "SOFTWARE\${PACKAGE_NAME}" "log_dir"     "$INSTDIR\log"
 	!insertmacro WriteRegStringIfUndef HKLM "SOFTWARE\${PACKAGE_NAME}" "priority"    "NORMAL_PRIORITY_CLASS"
 	!insertmacro WriteRegStringIfUndef HKLM "SOFTWARE\${PACKAGE_NAME}" "log_append"  "0"
+	!insertmacro WriteRegStringIfUndef HKLM "SOFTWARE\${PACKAGE_NAME}" "ovpn_admin_group" "OpenVPN Administrators"
 	!insertmacro WriteRegDWORDIfUndef  HKLM "SOFTWARE\${PACKAGE_NAME}" "disable_save_passwords"  0
 
 	${If} $iservice_existed == 0


### PR DESCRIPTION
This entry is optional as it is only used to override the default
value of "OpenVPN Administrators". However, in its absence, the service
logs an error indicating a missing registry key. Adding the registry entry
during installation prevents the error message and also provides a place
holder for users who want to customize the name of the admin group.

Trac: #892
Signed-off-by: Selva Nair <selva.nair@gmail.com>