### PR TITLE
include missing win32 libraries when using static built openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
       env: CHOST=i686-w64-mingw32 SCRIPT=generic/build
     - compiler: ": Win64"
       env: CHOST=x86_64-w64-mingw32 SCRIPT=generic/build
+    - compiler: ": Win32 + static"
+      env: DO_REALLY_STATIC=1 CHOST=i686-w64-mingw32 SCRIPT=generic/build
+    - compiler: ": Win64 + static"
+      env: DO_REALLY_STATIC=1 CHOST=x86_64-w64-mingw32 SCRIPT=generic/build
     - compiler: ": Win32 + depcache"
       env: CHOST=i686-w64-mingw32
       script:

--- a/generic/build
+++ b/generic/build
@@ -397,6 +397,13 @@ if [ -n "${BUILD_FOR_WINDOWS}" ]; then
 		${CONFIGOPTS} \
 		--sbindir=/bin \
 	"
+	if [ -n "${DO_STATIC}" ]; then
+		OPENSSL_LIBS=" \
+			${OPENSSL_LIBS} \
+			-lws2_32 \
+			-lgdi32 \
+		"
+	fi
 	export PKG_CONFIG="true"
 fi
 


### PR DESCRIPTION
addresses https://github.com/OpenVPN/openvpn-build/issues/111