### PR TITLE
Actually accept a given value to --sign-digest in windows-nsis/build

### DIFF
--- a/windows-nsis/build
+++ b/windows-nsis/build
@@ -138,7 +138,7 @@ while [ -n "$1" ]; do
 		--sign)
 			DO_SIGN=1
 			;;
-		--sign-digest)
+		--sign-digest=*)
 			SIGN_DIGEST="${v}"
 			;;
 		--sign-pkcs12=*)


### PR DESCRIPTION
Any value given to this arg will print the usage instead of being passed to
osslsigncode.

bug introduced in commit 0e3868e5

Signed-off-by: Gert van Dijk <gert@gertvandijk.net>