### PR TITLE
travis-ci: remove not needed openssl-1.1.0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ matrix:
       env: SCRIPT=windows-nsis/build-snapshot
     - compiler: ": complete"
       env: SCRIPT=windows-nsis/build-complete
-    - compiler: ": snapshot"
-      env: SCRIPT=windows-nsis/build-snapshot OPENSSL_VERSION=1.1.0g
   exclude:
     - compiler: gcc
 


### PR DESCRIPTION
openssl-1.1.0 is default already, no need for separate build anymore