### PR TITLE
build: fix Windows MinGW build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ for:
       only:
         - BUILDSYSTEM: cygwin
     build_script:
-      - "%CYGWIN%\\setup-%ARCH%.exe -g -q -P mingw64-i686-openssl,mingw64-x86_64-openssl,cygwin-devel,unzip,dos2unix,patch"
+      - "%CYGWIN%\\setup-%ARCH%.exe -g -q -P mingw64-i686-openssl,mingw64-x86_64-openssl,cygwin-devel,unzip,dos2unix,patch,liblz4-devel"
       - "%CYGWIN%\\bin\\bash -lc 'cp `which true` /usr/bin/man2html'"
       - "%CYGWIN%\\bin\\bash -lc 'cd /cygdrive/c/projects/%APPVEYOR_PROJECT_SLUG% ; generic/build'"
     artifacts:

--- a/generic/build
+++ b/generic/build
@@ -403,7 +403,6 @@ if [ -n "${BUILD_FOR_WINDOWS}" ]; then
 			-lgdi32 \
 		"
 	fi
-	export PKG_CONFIG="true"
 fi
 
 while [ -n "$1" ]; do


### PR DESCRIPTION
PKG_CHECK_MODULES macro is used to check the presence of given packages
and, if found, sets variables FOO_CFLAGS and FOO_LIBS, where FOO is a package
name and _CLAGS and _LIBS values are taken from package config, for example
from /lib/x86_64-linux-gnu/pkgconfig/liblz4.pc

Setting PKG_CONFIG to 'true' doesn't make much sense, since it makes
PKG_CHECK_MODULES to assume that any package is installed without any checks
and without setting FOO_CFLAGS/LIBS values.

This breaks, for example, Windows MinGW build on Windows build machine,
since it assumes the presence of liblz4 and enables callinf LZ4 API.
Because LZ4_LIBS is not set, we got linker errors.

Fix by removing PKG_CONFIG assignment to 'true'.

Signed-off-by: Lev Stipakov <lev@openvpn.net>