### PR TITLE
Prepare for OpenVPN 2.4.7 (version change, openssl-1.1.0j patch)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,20 @@ Directories
 
     Please refer to the README files in the subdirectories
     for further information.
+
+Patches
+**************************************************
+
+    The "generic/patches" directory contains patches applied
+    to openvpn or its dependencies ("products") before
+    starting the build. The product name is determined from
+    the first part of the patch filename before a dash ("-").
+
+    Currently patches are blindly applied regardless of the
+    production version. This is mostly a problem with OpenSSL
+    where differences between releases may be large enough to
+    cause patching failures. In those cases the offending
+    patch can be safely disabled. In particular, OpenSSL
+    1.1.0j requires a Makefile patch that will fail on
+    OpenSSL 1.1.1. That patch will be removed once upstream
+    has fixed the problem.

--- a/generic/build.vars
+++ b/generic/build.vars
@@ -1,11 +1,13 @@
 # -*- mode: sh; -*-
 BUILD_VERSION="001"
 
-OPENSSL_VERSION="${OPENSSL_VERSION:-1.1.0h}"
+# If you want to link against OpenSSL 1.1.1 you need to remove or disable
+# generic/patches/openssl-1.1.0j-issue7653.patch or the build will fail.
+OPENSSL_VERSION="${OPENSSL_VERSION:-1.1.0j}"
 PKCS11_HELPER_VERSION="${PKCS11_HELPER_VERSION:-1.22}"
 LZO_VERSION="${LZO_VERSION:-2.10}"
 TAP_WINDOWS_VERSION="${TAP_WINDOWS_VERSION:-9.22.1}"
-OPENVPN_VERSION="${OPENVPN_VERSION:-2.4.6}"
+OPENVPN_VERSION="${OPENVPN_VERSION:-2.4.7}"
 OPENVPN_GUI_VERSION="${OPENVPN_GUI_VERSION:-11}"
 
 OPENSSL_URL="${OPENSSL_URL:-https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz}"

--- a/generic/patches/openssl-1.1.0j-issue7653.patch
+++ b/generic/patches/openssl-1.1.0j-issue7653.patch
@@ -1,0 +1,10 @@
+--- openssl-1.0.0j/Configurations/unix-Makefile.tmpl.orig	2019-02-20 08:43:59.518452803 +0000
++++ openssl-1.0.0j/Configurations/unix-Makefile.tmpl	2019-02-20 09:11:32.730452803 +0000
+@@ -496,6 +496,7 @@
+ 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/$(LIBDIR)
+ 	@ : {- output_on() if windowsdll(); "" -}
+ 	@echo "*** Installing runtime files"
++	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/bin
+ 	@set -e; for s in dummy $(INSTALL_SHLIBS); do \
+ 		if [ "$$s" = "dummy" ]; then continue; fi; \
+ 		fn=`basename $$s`; \


### PR DESCRIPTION
Building OpenSSL 1.1.0j with mingw-w64 fails unless we patch the
makefile on the fly. The patch will not apply cleanly to OpenSSL 1.1.1,
so documentation was added to make note of it, as well as for the
openvpn-build patch management system in general.

URL: https://github.com/openssl/openssl/issues/7653
Signed-off-by: Samuli Seppänen <samuli@openvpn.net>