### PR TITLE
generic/build: use -O2 optimization

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,10 +14,14 @@ environment:
       ARCH: x86
       CYGWIN: C:\Cygwin
       CHOST: i686-w64-mingw32
+      RANLIB: gcc-ranlib
+      AR: gcc-ar
     - BUILDSYSTEM: cygwin
       ARCH: x86_64
       CYGWIN: C:\Cygwin64
       CHOST: x86_64-w64-mingw32
+      RANLIB: gcc-ranlib
+      AR: gcc-ar
     - BUILDSYSTEM: VS2017
 
 for:

--- a/generic/build
+++ b/generic/build
@@ -252,10 +252,10 @@ build_dep() {
 }
 
 build_openvpn() {
-
 	echo "Build openvpn"
 	cd "${BUILDROOT}/openvpn-${OPENVPN_VERSION}" || die "cd openvpn"
 	autoreconf -ivf # this allows to specify github url as OPENVPN_URL
+	CFLAGS="${CFLAGS} ${OPT_OPENVPN_CFLAGS}"
 	./configure ${CONFIGOPTS} ${EXTRA_OPENVPN_CONFIG} \
 		$(empty_ifelse "${DO_STATIC}" --enable-pkcs11 --disable-plugins) \
 		--enable-lzo \
@@ -267,7 +267,6 @@ build_openvpn() {
 }
 
 build_openvpn_gui() {
-
 	echo "Build openvpn-gui"
 	cd "${BUILDROOT}/openvpn-gui"* || die "cd openvpn gui"
 	./configure ${CONFIGOPTS} ${EXTRA_OPENVPN_GUI_CONFIG} \

--- a/windows-nsis/build-complete
+++ b/windows-nsis/build-complete
@@ -20,6 +20,7 @@ main() {
 			SOURCESROOT="$(pwd)/sources" \
 			BUILDROOT="${BUILD_TMPDIR}/build-${arch}" \
 			CHOST=${arch}-w64-mingw32 \
+			OPT_OPENVPN_CFLAGS="-O2 -flto" \
 			../generic/build \
 				--special-build="${SPECIAL_BUILD}" \
 				${WIN_USE_DEPCACHE:+--use-depcache=win-$arch} \


### PR DESCRIPTION
It turns out that we haven't had any optimization
enabled for mingw Windows build, and, for example,
Visual Studio generated code was significantly faster.

This turns optimization on, and according to
performance tests, it increases download bandwidth
by up to 20% and now we're on par with Visual Studio.

Signed-off-by: lstipakov@gmail.com <lstipakov@gmail.com>