### PR TITLE
windows-nsis: add wintun support

### DIFF
--- a/windows-nsis/build
+++ b/windows-nsis/build
@@ -97,6 +97,8 @@ main() {
 		-DOPENVPN_ROOT_X86_64="$(dospath "${OPENVPN_ROOT_X86_64}")" \
 		-DTAP_WINDOWS_INSTALLER="$(dospath "${TAP_WINDOWS_INSTALLER}")" \
 		${TAP_WINDOWS_INSTALLER:+-DUSE_TAP_WINDOWS} \
+		-DWINTUN_INSTALLER_X86_64="$(dospath "${WINTUN_INSTALLER_X86_64}")" \
+		-DWINTUN_INSTALLER_I686="$(dospath "${WINTUN_INSTALLER_I686}")" \
 		-DOPENVPNSERV2_EXECUTABLE="$(dospath "${OPENVPNSERV2_EXECUTABLE}")" \
 		-DEASYRSA_ROOT="$(dospath "${EASYRSA_ROOT}")" \
 		${EASYRSA_TARBALL:+-DUSE_EASYRSA} \
@@ -131,6 +133,12 @@ while [ -n "$1" ]; do
 			;;
 		--tap-windows=*)
 			TAP_WINDOWS_INSTALLER="${v}"
+			;;
+		--wintun-installer-x86-64=*)
+			WINTUN_INSTALLER_X86_64="${v}"
+			;;
+		--wintun-installer-i686=*)
+			WINTUN_INSTALLER_I686="${v}"
 			;;
 		--openvpnserv2=*)
 			OPENVPNSERV2_EXECUTABLE="${v}"

--- a/windows-nsis/build-complete
+++ b/windows-nsis/build-complete
@@ -12,6 +12,8 @@ main() {
 	"${WGET}" ${WGET_OPTS} --directory-prefix=${BUILD_TMPDIR} "${EASY_RSA_URL}" || die "get easy-rsa"
 	"${WGET}" ${WGET_OPTS} --directory-prefix=${BUILD_TMPDIR} "${TAP_WINDOWS_INSTALLER_URL}" || die "get tap-windows"
 	"${WGET}" ${WGET_OPTS} --directory-prefix=${BUILD_TMPDIR} "${OPENVPNSERV2_URL}" || die "get openvpnserv2"
+	"${WGET}" ${WGET_OPTS} --directory-prefix=${BUILD_TMPDIR} "${WINTUN_INSTALLER_X86_64_URL}" || die "get wintun installer x64"
+	"${WGET}" ${WGET_OPTS} --directory-prefix=${BUILD_TMPDIR} "${WINTUN_INSTALLER_I686_URL}" || die "get wintun installer i686"
 
 	for arch in i686 x86_64; do
 		echo "BUILDING ${arch}"
@@ -38,6 +40,8 @@ main() {
 			--openvpn-bin-tarball-x86_64=$(ls ${BUILD_TMPDIR}/image-x86_64/openvpn-x86_64-*-bin.*) \
 			--easy-rsa-tarball=$(ls ${BUILD_TMPDIR}/easy-rsa-*) \
 			--tap-windows=$(ls ${BUILD_TMPDIR}/tap-windows-*) \
+			--wintun-installer-x86-64="${BUILD_TMPDIR}/wintun-amd64.msi" \
+			--wintun-installer-i686="${BUILD_TMPDIR}/wintun-x86.msi" \
 			--openvpnserv2=$(ls ${BUILD_TMPDIR}/openvpnserv2*) \
 			--output-dir="${OUTPUT_DIR}" \
 			${DO_SIGN:+--sign} \

--- a/windows-nsis/build-complete.vars
+++ b/windows-nsis/build-complete.vars
@@ -8,6 +8,8 @@ OPENVPNSERV2_VERSION="${OPENVPNSERV2_VERSION:-1.3.0.0}"
 EASY_RSA_URL="${EASY_RSA_URL:-http://build.openvpn.net/downloads/releases/easy-rsa-${EASY_RSA_VERSION}.tar.gz}"
 TAP_WINDOWS_INSTALLER_URL="${TAP_WINDOWS_INSTALLER_URL:-http://build.openvpn.net/downloads/releases/tap-windows-${TAP_WINDOWS_INSTALLER_VERSION}-Win7.exe}"
 OPENVPNSERV2_URL="${OPENVPNSERV2_URL:-http://build.openvpn.net/downloads/releases/openvpnserv2-${OPENVPNSERV2_VERSION}.exe}"
+WINTUN_INSTALLER_X86_64_URL="${WINTUN_INSTALLER_X86_64:-https://staging.openvpn.net/openvpn2/wintun-amd64.msi}"
+WINTUN_INSTALLER_I686_URL="${WINTUN_INSTALLER_I686:-https://staging.openvpn.net/openvpn2/wintun-x86.msi}"
 
 WGET="${WGET:-wget}"
 


### PR DESCRIPTION
This adds "wintun" option to Windows installer,
which installs wintun driver and creates tun device.

Wintun installer is based on wintun's "msi-example" -
a wrapper over MSM - wintun's official distribution way.

Signed-off-by: Lev Stipakov <lev@openvpn.net>