### PR TITLE
msvc: fix dependencies URLs

### DIFF
--- a/msvc/build-env.bat
+++ b/msvc/build-env.bat
@@ -11,11 +11,11 @@ if "%OPENVPN_SOURCE%"=="" set OPENVPN_SOURCE=tarball
 
 set OPENSSL_URL=http://www.openssl.org/source/openssl-%OPENSSL_VERSION%.tar.gz
 set LZO_URL=http://www.oberhumer.com/opensource/lzo/download/lzo-%LZO_VERSION%.tar.gz
-set PKCS11_URL=https://vorboss.dl.sourceforge.net/project/opensc/pkcs11-helper/pkcs11-helper-%PKCS11_VERSION%.tar.bz2
+set PKCS11_URL=https://netix.dl.sourceforge.net/project/opensc/pkcs11-helper/pkcs11-helper-%PKCS11_VERSION%.tar.bz2
 set TAP_URL=https://github.com/OpenVPN/tap-windows6/archive/%TAP_VERSION%.zip
 set OPENVPN_URL=https://github.com/%GITHUB_USER%/openvpn/archive/%OPENVPN_VERSION%.tar.gz
 set OPENVPN_GIT=https://github.com/OpenVPN/openvpn.git
-set P7ZIP_URL=https://datapacket.dl.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip
+set P7ZIP_URL=https://netcologne.dl.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip
 
 if "%ProgramFiles(x86)%"=="" set ProgramFiles(x86)=%ProgramFiles%
 if "%VSCOMNTOOLS%"=="" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\Tools


### PR DESCRIPTION
This fixes download URLs for pkcs11 and p7zip.

Signed-off-by: Lev Stipakov <lstipakov@gmail.com>