### PR TITLE
Upgrade to Visual Studio 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,9 +41,9 @@ for:
       only:
         - BUILDSYSTEM: VS2019
     init:
-      - choco install -y --allow-empty-checksums nasm
+      - choco install -y --allow-empty-checksums nasm strawberryperl
     build_script:
-      - set PATH=C:\Program Files\NASM;%PATH%
+      - set PATH=C:\Program Files\NASM;C:\Strawberry\Perl\bin;%PATH%
       - msvc/build.bat
     artifacts:
       - path: msvc/image/bin

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,5 @@
 version: "openvpn-build-{build}"
 
-image:
-- Visual Studio 2017
-
 skip_commits:
   files:
     - .travis.yml
@@ -10,19 +7,22 @@ skip_commits:
 environment:
   CBUILD: x86_64-pc-linux-gnu
   matrix:
-    - BUILDSYSTEM: cygwin
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BUILDSYSTEM: cygwin
       ARCH: x86
       CYGWIN: C:\Cygwin
       CHOST: i686-w64-mingw32
       RANLIB: gcc-ranlib
       AR: gcc-ar
-    - BUILDSYSTEM: cygwin
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BUILDSYSTEM: cygwin
       ARCH: x86_64
       CYGWIN: C:\Cygwin64
       CHOST: x86_64-w64-mingw32
       RANLIB: gcc-ranlib
       AR: gcc-ar
-    - BUILDSYSTEM: VS2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      BUILDSYSTEM: VS2019
 
 for:
   -
@@ -39,7 +39,7 @@ for:
   -
     matrix:
       only:
-        - BUILDSYSTEM: VS2017
+        - BUILDSYSTEM: VS2019
     init:
       - choco install -y --allow-empty-checksums nasm
     build_script:

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Directories
     OpenVPN using mingw_w64 (e.g. Linux -> Windows).
 
     The "msvc" subdir is used to compile OpenVPN on Windows
-    for Windows using Microsoft Visual Studio 2017.
+    for Windows using Microsoft Visual Studio 2019.
 
     The "windows-nsis" subdir contains scripts to
     cross-compile and package OpenVPN for Windows.

--- a/msvc/README
+++ b/msvc/README
@@ -6,7 +6,7 @@ About
     and all it's dependencies using Microsoft Visual C.
 
     You need to install:
-      - Visual Studio 2017 (Build Tools for VS will also work)
+      - Visual Studio 2019 (Build Tools for VS will also work)
       - Perl (Strawberry or ActiveState, required for building OpenSSL)
       - NASM (required for building OpenSSL)
 
@@ -26,6 +26,6 @@ Usage
 
     Development environment is ready. Open solution file in Visual Studio (select "x64" in "Solution Platforms") :
 
-      openvpn\openvpn.sln
+      > openvpn\openvpn.sln
 
     and start coding!

--- a/msvc/build-env.bat
+++ b/msvc/build-env.bat
@@ -18,12 +18,12 @@ set OPENVPN_GIT=https://github.com/OpenVPN/openvpn.git
 set P7ZIP_URL=https://netcologne.dl.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip
 
 if "%ProgramFiles(x86)%"=="" set ProgramFiles(x86)=%ProgramFiles%
-if "%VSCOMNTOOLS%"=="" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\Tools
-if not exist "%VSCOMNTOOLS%" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools
-if not exist "%VSCOMNTOOLS%" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools
+if "%VSCOMNTOOLS%"=="" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\Common7\Tools
+if not exist "%VSCOMNTOOLS%" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools
+if not exist "%VSCOMNTOOLS%" set VSCOMNTOOLS=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools
 if "%VSHOME%"=="" SET VSHOME=%VSCOMNTOOLS%\..\..
 if "%VCHOME%"=="" SET VCHOME=%VSHOME%\VC
-if not exist "%VSCOMNTOOLS%" SET VCHOME=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\VC
+if not exist "%VSCOMNTOOLS%" SET VCHOME=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\VC
 
 if "%P7Z%"=="" SET P7Z=tools\7za.exe
 if "%GIT%"=="" SET GIT=c:\Program Files\Git\bin\git.exe
@@ -31,3 +31,6 @@ if "%NASM_DIR%"=="" SET NASM_DIR=c:\Program Files\NASM
 
 if "%TARGET%"=="" SET TARGET=%ROOT%\image
 if "%RELEASE%"=="" SET RELEASE=Release
+
+rem OpenSSL build defines RC as "1" when undefined on some environments.
+if "%RC%"=="" SET RC=rc

--- a/msvc/build.bat
+++ b/msvc/build.bat
@@ -18,7 +18,7 @@ rem along with this program.  If not, see <http://www.gnu.org/licenses/>.
 rem
 
 rem Required software:
-rem - Visual Studio 2017
+rem - Visual Studio 2019
 rem - perl
 rem
 rem To build only openvpn, run


### PR DESCRIPTION
As openvpn's repo already switched MSVC to VS2019, the openvpn-build should follow.