### PR TITLE
windows-nsis: Refine the WoW64 decision logic

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -600,7 +600,7 @@ ${IfNot} ${AtLeastWinVista}
 
 ${EndIf}
 
-	${If} ${RunningX64}
+	${If} ${IsWow64}
 		SetRegView 64
 		; Change the installation directory to C:\Program Files, but only if the
 		; user has not provided a custom install location.
@@ -729,7 +729,7 @@ Function un.onInit
 	ClearErrors
 	!insertmacro MULTIUSER_UNINIT
 	SetShellVarContext all
-	${If} ${RunningX64}
+	${If} ${IsWow64}
 		SetRegView 64
 	${EndIf}
 FunctionEnd


### PR DESCRIPTION
The registry and file reflection is also present on ARM64 platform. Therefore, the reflection logic should resemble `${RunningX64} || ${RunningArm64}` or `${IsWow64}` or `!${RunningX86}` for short.