### PR TITLE
windows-nsis: Remove service dependency on tap0901

### DIFF
--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -344,7 +344,7 @@ Section /o "${PACKAGE_NAME} Service" SecService
 	File /oname=openvpnserv2.exe "${OPENVPNSERV2_EXECUTABLE}"
 
 	DetailPrint "Installing OpenVPN Service..."
-	SimpleSC::InstallService "OpenVPNService" "OpenVPNService" "16" "3" '"$INSTDIR\bin\openvpnserv2.exe"' "tap0901/dhcp" "" ""
+	SimpleSC::InstallService "OpenVPNService" "OpenVPNService" "16" "3" '"$INSTDIR\bin\openvpnserv2.exe"' "dhcp" "" ""
 SectionEnd
 
 Function CoreSetup
@@ -408,14 +408,14 @@ Function CoreSetup
 		SimpleSC::SetServiceBinaryPath "OpenVPNServiceInteractive" '"$INSTDIR\bin\openvpnserv.exe"'
 	${Else}
 		DetailPrint "Installing OpenVPN Interactive Service..."
-		SimpleSC::InstallService "OpenVPNServiceInteractive" "OpenVPN Interactive Service" "32" "2" '"$INSTDIR\bin\openvpnserv.exe"' "tap0901/dhcp" "" ""
+		SimpleSC::InstallService "OpenVPNServiceInteractive" "OpenVPN Interactive Service" "32" "2" '"$INSTDIR\bin\openvpnserv.exe"' "dhcp" "" ""
 	${EndIf}
 
 	${If} $legacy_service_existed == 0
 		SimpleSC::SetServiceBinaryPath "OpenVPNServiceLegacy" '"$INSTDIR\bin\openvpnserv.exe"'
 	${Else}
 		DetailPrint "Installing OpenVPN Legacy Service..."
-		SimpleSC::InstallService "OpenVPNServiceLegacy" "OpenVPN Legacy Service" "32" "3" '"$INSTDIR\bin\openvpnserv.exe"' "tap0901/dhcp" "" ""
+		SimpleSC::InstallService "OpenVPNServiceLegacy" "OpenVPN Legacy Service" "32" "3" '"$INSTDIR\bin\openvpnserv.exe"' "dhcp" "" ""
 	${EndIf}
 
 FunctionEnd


### PR DESCRIPTION
When there are no TAP-Windows6 adapters present, the tap0901 driver's service is not (and cannot be) started. This prevents all OpenVPN services from starting. The no-TAP-Windows6/Wintun adapters present situation is checked at run-time.