### PR TITLE
msvc: support for 32bit architecture

### DIFF
--- a/msvc/build-env.bat
+++ b/msvc/build-env.bat
@@ -28,8 +28,8 @@ if not exist "%VSCOMNTOOLS%" SET VCHOME=%ProgramFiles(x86)%\Microsoft Visual Stu
 if "%P7Z%"=="" SET P7Z=tools\7za.exe
 if "%GIT%"=="" SET GIT=c:\Program Files\Git\bin\git.exe
 if "%NASM_DIR%"=="" SET NASM_DIR=c:\Program Files\NASM
-
-if "%TARGET%"=="" SET TARGET=%ROOT%\image
+if "%ARCH%"=="" SET ARCH=64
+if "%TARGET%"=="" SET TARGET=%ROOT%\image%ARCH%
 if "%RELEASE%"=="" SET RELEASE=Release
 
 rem OpenSSL build defines RC as "1" when undefined on some environments.


### PR DESCRIPTION
Previously we had 64bit hardcoded. This change allows
to build dependencies and openvpn for 32bit as well:

  set ARCH=32&& build.bat

Default architecture is still 64.

Signed-off-by: Lev Stipakov <lev@openvpn.net>