### PR TITLE
Enable O3 optimization for Windows binaries

### DIFF
--- a/generic/build.vars
+++ b/generic/build.vars
@@ -42,7 +42,7 @@ EXTRA_OPENSSL_CONFIG="${EXTRA_OPENSSL_CONFIG:--static-libgcc}" # uncomment if op
 #EXTRA_OPENVPN_CONFIG
 
 case "${CHOST}" in
-     *mingw*) EXTRA_TARGET_CFLAGS="-Wl,--dynamicbase,--nxcompat";;
+     *mingw*) EXTRA_TARGET_CFLAGS="-Wl,--dynamicbase,--nxcompat -O3";;
 esac
 
 # You can enable --high-entropy-va for 64-bit builds if you have recent enough

--- a/windows-nsis/build-complete
+++ b/windows-nsis/build-complete
@@ -22,7 +22,7 @@ main() {
 			SOURCESROOT="$(pwd)/sources" \
 			BUILDROOT="${BUILD_TMPDIR}/build-${arch}" \
 			CHOST=${arch}-w64-mingw32 \
-			OPT_OPENVPN_CFLAGS="-O2 -flto" \
+			OPT_OPENVPN_CFLAGS="-flto" \
 			../generic/build \
 				--special-build="${SPECIAL_BUILD}" \
 				${WIN_USE_DEPCACHE:+--use-depcache=win-$arch} \


### PR DESCRIPTION
We used to have -O2 optimization for binaries in NSIS installer

https://github.com/OpenVPN/openvpn-build/pull/153/commits/7402da3e54dea03c628b4440b9b01ab33b694b66

but it was implemented in ./build-complete, which is not used when
building binaries for MSI installer.

Add O3 flag to EXTRA_TARGET_CFLAGS, which is then used as
CFLAGS when building all binaries.

This also fixes missing optimization for openssl builds. Before OpenSSL 1.1.1,
openssl ignored CFLAGS env variabe and used its own value, which included O3.
Starting from 1.1.1, OpenSSL uses CFLAGS if it has been defined.

https://github.com/openssl/openssl/commit/0342e42d864b7a670b4403389df057c4da6d7975

Since we have defined CFLAGS without O3, we didn't use optimization when
building OpenSSL.

Before this fix there was no O3 in compiler options:

    openssl build:
    i686-w64-mingw32-gcc  -I. -Iinclude -m32 -Wl,--dynamicbase,--nxcompat -static-libgcc <...>

    openvpn build:
    i686-w64-mingw32-gcc <...> -Wall -Wno-unused-parameter -Wno-unused-function -Wno-stringop-truncation  -Wl,--dynamicbase,--nxcompat  -std=c99 -MT status.o -MD -MP -MF .deps/status.Tpo -c -o status.o status.c

    c:\Temp>openssl.exe version -f
    compiler: i686-w64-mingw32-gcc -m32 -Wl,--dynamicbase,--nxcompat -static-libgcc <...>

After this fix O3 has appeared (even twice in openssl, but this is some glitch in its build system) :

    openssl build:
    i686-w64-mingw32-gcc  -I. -Iinclude -m32 -Wl,--dynamicbase,--nxcompat -O3 -O3 -static-libgcc <...>

    openvpn build:
    i686-w64-mingw32-gcc <...>  -Wall -Wno-unused-parameter -Wno-unused-function -Wno-stringop-truncation  -Wl,--dynamicbase,--nxcompat -O3  -std=c99 -MT status.o -MD -MP -MF .deps/status.Tpo -c -o status.o status.c

    openssl version -f
    c:\Temp\----\1>openssl.exe version -f
    compiler: i686-w64-mingw32-gcc -m32 -Wl,--dynamicbase,--nxcompat -O3 -O3 -static-libgcc <...>

Signed-off-by: Lev Stipakov <lev@openvpn.net>