### PR TITLE
Bump OpenVPN version for snapshot build

### DIFF
--- a/windows-nsis/build-snapshot
+++ b/windows-nsis/build-snapshot
@@ -12,7 +12,7 @@ get_full_path() {
 }
 
 GIT="${GIT:-git}"
-OPENVPN_VERSION="${OPENVPN_VERSION:-2.5_git}"; export OPENVPN_VERSION
+OPENVPN_VERSION="${OPENVPN_VERSION:-2.6_git}"; export OPENVPN_VERSION
 OPENVPN_BRANCH="${OPENVPN_BRANCH:-master}"
 OPENVPN_URL="${OPENVPN_URL:-http://github.com/OpenVPN/openvpn.git}"
 


### PR DESCRIPTION
Same issue as during [last version change](/OpenVPN/openvpn-build/commit/2eac27).

Was updated in OpenVPN repo [2020-08-12](/OpenVPN/openvpn/commit/f7432a9).
Error got masked due to previous problems with missing manpage (fixed by installing [python-docutils](/OpenVPN/openvpn-build/commit/ecc9771)).