### PR TITLE
Support for ovpn-dco

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -60,7 +60,8 @@ clean	Cleans intermediate and output files</example>
                     "programFilesPath": "ProgramFilesFolder",
                     "openSSLPlat": "",
                     "wixPlat": "x86",
-                    "wixLinkDepenencies": []
+                    "wixLinkDepenencies": [],
+                    "ovpnDcoPath": BuildPath(buildPath, "x86", "ovpn-dco")
                 },
 
                 "amd64": {
@@ -69,7 +70,8 @@ clean	Cleans intermediate and output files</example>
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-x64",
                     "wixPlat": "x64",
-                    "wixLinkDepenencies": []
+                    "wixLinkDepenencies": [],
+                    "ovpnDcoPath": BuildPath(buildPath, "amd64", "ovpn-dco")
                 }
             }
 
@@ -136,6 +138,22 @@ clean	Cleans intermediate and output files</example>
                             ver.define["PRODUCT_WINTUN_URL_" + plat],
                             ["version.m4"]));
 
+                        // Downloading ovpn-dco
+                        b.pushRule(new DownloadBuildRule(
+                            BuildPath(p.buildPath, "ovpn-dco.zip"),
+                            ver.define["PRODUCT_OVPN_DCO_URL_" + plat],
+                            ["version.m4"]));
+
+                        // Extracting ovpn-dco
+                        b.pushRule(new ExtractBuildRule(
+                            [
+                                BuildPath(p.buildPath, "ovpn-dco", "ovpn-dco.inf")
+                            ],
+                            p.ovpnDcoPath,
+                            BuildPath(p.buildPath, "ovpn-dco.timestamp"),
+                            BuildPath(p.buildPath, "ovpn-dco.zip"),
+                            []));
+
                         // WiX compiler flags
                         var wixCompilerFlags = [
                             "-ext WixNetFxExtension",
@@ -193,7 +211,8 @@ clean	Cleans intermediate and output files</example>
                             "-b build=\""         + _CMD(buildPath    ) + "\"",
                             "-b openvpn=\""       + _CMD(p.openVPNPath) + "\"",
                             "-b easyrsa=\""       + _CMD(easyRSAPath  ) + "\"",
-                            "-b openvpnserv2=\""  + _CMD(buildPath    ) + "\""
+                            "-b openvpnserv2=\""  + _CMD(buildPath    ) + "\"",
+                            "-b ovpndco=\""       + _CMD(p.ovpnDcoPath) + "\""
                         ];
 
                         // WiX linking
@@ -220,6 +239,7 @@ clean	Cleans intermediate and output files</example>
                                 BuildPath(p.buildPath, "license.txt"),
                                 BuildPath(p.buildPath, "tap-windows6.msm"),
                                 BuildPath(p.buildPath, "wintun.msm"),
+                                BuildPath(p.buildPath, "ovpn-dco", "ovpn-dco.inf"),
                                 BuildPath(p.openVPNPath, "bin", "libcrypto-1_1" + p.openSSLPlat + ".dll"),
                                 BuildPath(p.openVPNPath, "bin", "liblzo2-2.dll"),
                                 BuildPath(p.openVPNPath, "bin", "libopenvpnmsica.dll"),

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -51,6 +51,10 @@
             Id="libopenvpnmsica.dll"
             SourceFile="!(bindpath.openvpn)bin\libopenvpnmsica.dll"/>
 
+        <Binary
+            Id="CustomActions.CA.dll"
+            SourceFile="!(bindpath.ovpndco)\CustomActions.CA.dll"/>
+
         <Property Id="ARPPRODUCTICON" Value="openvpn.ico"/>
         <Property Id="ARPURLINFOABOUT" Value="https://openvpn.net/community/"/>
         <Property Id="ARPURLUPDATEINFO" Value="https://openvpn.net/community-downloads/"/>
@@ -62,6 +66,12 @@
         <Property Id="DISABLEROLLBACK" Value="yes"/>
         <Property Id="EDITOR" Value="notepad.exe"/>
         <PropertyRef Id="NETFRAMEWORK40FULL"/>
+
+        <Property Id="WIN102004" Secure="yes">
+            <DirectorySearch Id="searchSystem" Path="[SystemFolder]" Depth="0">
+                <FileSearch Id="searchFile" Name="advapi32.dll" MinVersion="6.3.19041.0"/>
+            </DirectorySearch>
+        </Property>
 
         <!--
             Overwrite all files regardless of versions on install
@@ -87,6 +97,8 @@
         <Property Id="ACTIVETAPWINDOWS6ADAPTERS" Secure="yes"/>
         <Property Id="WINTUNADAPTERS" Secure="yes"/>
         <Property Id="ACTIVEWINTUNADAPTERS" Secure="yes"/>
+        <Property Id="OVPNDCOADAPTERS" Secure="yes"/>
+        <Property Id="ACTIVEOVPNDCOADAPTERS" Secure="yes"/>
 
 
         <!--
@@ -991,6 +1003,20 @@
                         </Component>
                     </Directory>
                 </Directory>
+
+                <Directory Id="CommonFiles" Name="Common Files">
+                    <Directory Id="OVPNDCO" Name="ovpn-dco">
+                        <Component Id="CMP_ovpn_dco.inf" Guid="4BE20469-2292-4AE2-B953-49AA0DA4165E">
+                            <File Id="ovpndco.inf" Name="ovpn-dco.inf" Source="!(bindpath.ovpndco)\ovpn-dco.inf" KeyPath="yes" />
+                        </Component>
+                        <Component Id="CMP_ovpn_dco.cat" Guid="EB59AE6E-191E-4FE1-B414-005217348183">
+                            <File Id="ovpndco.cat" Name="ovpn-dco.cat" Source="!(bindpath.ovpndco)\ovpn-dco.cat" KeyPath="yes" />
+                        </Component>
+                        <Component Id="CMP_ovpn_dco.sys" Guid="0007BFDB-42A9-4F67-BDD9-AB3B797DEF1F">
+                            <File Id="ovpndco.sys" Name="ovpn-dco.sys" Source="!(bindpath.ovpndco)\ovpn-dco.sys" KeyPath="yes" />
+                        </Component>
+                    </Directory>
+                </Directory>
             </Directory>
 
             <Directory Id="ProgramMenuFolder">
@@ -1311,6 +1337,9 @@
             <ProgressText Action="$(var.PRODUCT_TAP_WIN_COMPONENT_ID)_Process">Processing TAP-Windows6 driver</ProgressText>
             <ProgressText Action="EvaluateWintun">Evaluating Wintun driver</ProgressText>
             <ProgressText Action="ProcessWintun">Processing Wintun driver</ProgressText>
+            <ProgressText Action="OvpnDcoEvaluate">Evaluating ovpn-dco driver</ProgressText>
+            <ProgressText Action="OvpnDcoProcess">Processing ovpn-dco driver</ProgressText>
+            <ProgressText Action="OvpnDcoCheckReboot">Checking if reboot is required</ProgressText>
         </UI>
 
 
@@ -1325,7 +1354,14 @@
         <CustomAction Id="InstallTUNTAPAdaptersCommit"     BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDeferredAction" Execute="commit"   Impersonate="no"/>
         <CustomAction Id="InstallTUNTAPAdaptersRollback"   BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDeferredAction" Execute="rollback" Impersonate="no"/>
 
+        <!-- ovpn-dco driver -->
+        <CustomAction Id="OvpnDcoEvaluate"    BinaryKey="CustomActions.CA.dll" DllEntry="Evaluate" Execute="immediate"/>
+        <CustomAction Id="OvpnDcoProcess"     BinaryKey="CustomActions.CA.dll" DllEntry="Process" Execute="deferred" Impersonate="no"/>
+        <CustomAction Id="OvpnDcoCheckReboot" BinaryKey="CustomActions.CA.dll" DllEntry="CheckReboot" Execute="immediate"/>
+
         <InstallExecuteSequence>
+            <Custom Action="OvpnDcoEvaluate"                 Before="OvpnDcoProcess"/>
+            <Custom Action="OvpnDcoProcess"                   After="InstallFiles" />
             <Custom Action="EvaluateTUNTAPAdapters"           After="ProcessComponents"/>
             <Custom Action="UninstallTUNTAPAdapters"          After="DeleteServices"/>
             <Custom Action="UninstallTUNTAPAdaptersCommit"    After="UninstallTUNTAPAdapters"/>
@@ -1333,6 +1369,8 @@
             <Custom Action="InstallTUNTAPAdapters"           Before="InstallServices"/>
             <Custom Action="InstallTUNTAPAdaptersCommit"      After="InstallTUNTAPAdapters"/>
             <Custom Action="InstallTUNTAPAdaptersRollback"   Before="InstallTUNTAPAdapters"/>
+
+            <Custom Action="OvpnDcoCheckReboot"               After="InstallFinalize"/>
         </InstallExecuteSequence>
 
         <UI>
@@ -1344,7 +1382,6 @@
             <ProgressText
                 Action="InstallTUNTAPAdapters"
                 Template="[1]: [2] [3] [4]">Creating TUN/TAP adapters</ProgressText>
-
             <Error Id="2550">OpenVPNMSICA: [2]</Error>
             <Error Id="2551">OpenVPNMSICA: [2]  Error [3]: [4]</Error>
         </UI>
@@ -1412,6 +1449,14 @@
                 <Data Column="HardwareId" >Wintun</Data>
                 <Data Column="Condition"  ><![CDATA[NOT WINTUNADAPTERS]]></Data>
                 <Data Column="Component_" >reg11F81A5FFB49D87B59FD3777E57FF853.C28309D9_1954_4F2D_A7D1_228850092460</Data>
+            </Row>
+
+            <Row>
+                <Data Column="Adapter"    >ovpndco</Data>
+                <Data Column="DisplayName">ovpn-dco|$(var.PRODUCT_NAME) Data Channel Offload</Data>
+                <Data Column="HardwareId" >ovpn-dco</Data>
+                <Data Column="Condition"  ><![CDATA[NOT OVPNDCOADAPTERS]]></Data>
+                <Data Column="Component_" >CMP_ovpn_dco.inf</Data>
             </Row>
         </CustomTable>
 
@@ -1584,6 +1629,19 @@
                 AllowAdvertise="no">
                 <ComponentRef Id="shortcut.bin.tapctl.exe.create.Wintun"/>
                 <MergeRef Id="WintunMergeModule"/>
+            </Feature>
+
+            <Feature
+                Id="Drivers.OvpnDco"
+                Title="ovpn-dco"
+                Description="OpenVPN Data Channel Offload"
+                Level="0"
+                ConfigurableDirectory="PRODUCTDIR"
+                AllowAdvertise="no">
+                <ComponentRef Id="CMP_ovpn_dco.inf"/>
+                <ComponentRef Id="CMP_ovpn_dco.cat"/>
+                <ComponentRef Id="CMP_ovpn_dco.sys"/>
+                <Condition Level="1">WIN102004</Condition>
             </Feature>
         </Feature>
 

--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -12,6 +12,10 @@ dnl Wintun binaries
 define([PRODUCT_WINTUN_URL_x86],       [https://www.wintun.net/builds/wintun-x86-0.8.1.msm])
 define([PRODUCT_WINTUN_URL_amd64],     [https://www.wintun.net/builds/wintun-amd64-0.8.1.msm])
 
+dnl ovpn-dco binaries
+define([PRODUCT_OVPN_DCO_URL_x86],     [https://lestisoftware.fi/ovpn-dco-amd64-0.4.zip])
+define([PRODUCT_OVPN_DCO_URL_amd64],   [https://lestisoftware.fi/ovpn-dco-amd64-0.4.zip])
+
 dnl OpenVPNServ2.exe binary
 define([OPENVPNSERV2_URL], [http://build.openvpn.net/downloads/releases/openvpnserv2-1.4.0.1.exe])
 


### PR DESCRIPTION
This adds support of ovpn-dco kernel driver installation.

Installer script (build.wsf) downloads ovpn-dco-<platform>-<version>.zip
from a trusted server and unpacks it. The archive contains
signed driver files (ovpn-dco.inf/cat/sys) and C#-bases custom
actions DLL (which source is part of ovpn-dco-win repo).

Define a new feature (ovpn-dco), which references 3 components,
each of them corresponds to ovpn-dco file. Since ovpn-dco driver
works starting from Windows 10 2004, add a (hacky) Windows
version check and disable this feature for earlier Windows versions.

Define OvpnDcoEvaluate immediate custom action, which checks
component installer state (install/remove) and set CustomActionData
with necessary information for OvpnDcoProcess action.

Define OvpnDcoProcess deferred custom action, which installs/uninstalls/noops
ovpn-dco driver by calling pnputil.exe. If pnputil.exe requires reboot,
OvpnDcoProcess creates a special file  in user's %TEMP% directory which is
checked by OvpnDcoCheckReboot action.

Define OvpnDcoCheckReboot immediate custom action, which checks above
file in user's %TEMP% directory and if it is presented, schedules a
reboot after installation.

Custom actions are stored in CustomActions.CA.dll, which is product
of C# project CustomActions, which is part of ovpn-dco-win
repo/solution.

Adapters with ovpn-dco hwid are managed by already existing custom actions
(EvaluateTUNTAPAdapters/(Un)InstallTUNTAPAdapters) from libopenvpnmsica.dll.

Signed-off-by: Lev Stipakov <lev@openvpn.net>