### PR TITLE
msi: properly schedule reboot in the end of installation

### DIFF
--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -1324,6 +1324,7 @@
         <CustomAction Id="InstallTUNTAPAdapters"           BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDeferredAction" Execute="deferred" Impersonate="no"/>
         <CustomAction Id="InstallTUNTAPAdaptersCommit"     BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDeferredAction" Execute="commit"   Impersonate="no"/>
         <CustomAction Id="InstallTUNTAPAdaptersRollback"   BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDeferredAction" Execute="rollback" Impersonate="no"/>
+        <CustomAction Id="CheckAndScheduleReboot"          BinaryKey="libopenvpnmsica.dll" DllEntry="CheckAndScheduleReboot"/>
 
         <InstallExecuteSequence>
             <Custom Action="EvaluateTUNTAPAdapters"           After="ProcessComponents"/>
@@ -1333,6 +1334,7 @@
             <Custom Action="InstallTUNTAPAdapters"           Before="InstallServices"/>
             <Custom Action="InstallTUNTAPAdaptersCommit"      After="InstallTUNTAPAdapters"/>
             <Custom Action="InstallTUNTAPAdaptersRollback"   Before="InstallTUNTAPAdapters"/>
+            <Custom Action="CheckAndScheduleReboot"           After="InstallFinalize"/>
         </InstallExecuteSequence>
 
         <UI>


### PR DESCRIPTION
Currently reboot is scheduled by calling MsiSetMode() in deferred
custom action ProcessDeferredAction. This approach doesn't work.

Invoke CheckAndScheduleReboot immediate custom action which
schedules reboot. The action code is a part of openvpn project.

Signed-off-by: Lev Stipakov <lev@openvpn.net>