### PR TITLE
generic/build: build lz4 as dynamic library

### DIFF
--- a/generic/build
+++ b/generic/build
@@ -239,19 +239,15 @@ build_dep() {
 	else
 		echo "Build lz4"
 		cd "${BUILDROOT}/lz4"* || die "cd lz4"
-		echo ./configure ${CONFIGOPTS} ${EXTRA_LZ4_CONFIG} \
-			$(empty_ifelse "${DO_STATIC}" --enable-shared --disable-shared) \
-			|| die "Configure lz4"
 		# lz4 does not have a configure, so pass CC/LD instead
-		# ... and we only want the static library
 		${MAKE} ${MAKEOPTS} CC=${CHOST}-gcc LD=${CHOST}-gcc \
 			WINDRES=${CHOST}-windres TARGET_OS=MINGW32 \
-			BUILD_STATIC=yes BUILD_SHARED=no \
+			BUILD_STATIC=no BUILD_SHARED=yes \
 			PREFIX=/ DESTDIR="${INSTALL_ROOT}" V=1 \
 			|| die "make lz4"
 		${MAKE} ${MAKEOPTS} CC=${CHOST}-gcc LD=${CHOST}-gcc \
 			WINDRES=${CHOST}-windres TARGET_OS=MINGW32 \
-			BUILD_STATIC=yes BUILD_SHARED=no \
+			BUILD_STATIC=no BUILD_SHARED=yes \
 			PREFIX=/ DESTDIR="${INSTALL_ROOT}" V=1 install \
 			|| die "make lz4"
 

--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -59,6 +59,7 @@ clean	Cleans intermediate and output files</example>
                     "openVPNPath": BuildPath(rootPath, "generic", "image-win32", "openvpn"),
                     "programFilesPath": "ProgramFilesFolder",
                     "openSSLPlat": "",
+                    "LZ4DLL": "liblz4",
                     "wixPlat": "x86",
                     "wixLinkDepenencies": []
                 },
@@ -68,6 +69,7 @@ clean	Cleans intermediate and output files</example>
                     "openVPNPath": BuildPath(rootPath, "generic", "image-win64", "openvpn"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-x64",
+                    "LZ4DLL": "liblz4",
                     "wixPlat": "x64",
                     "wixLinkDepenencies": []
                 }
@@ -151,7 +153,8 @@ clean	Cleans intermediate and output files</example>
                             "-dUPGRADE_CODE=\""                 + _CMD(ver.define["UPGRADE_CODE_" + plat        ]) + "\"",
                             "-dCONFIG_EXTENSION=\""             + _CMD(ver.define["CONFIG_EXTENSION"            ]) + "\"",
                             "-dPROGRAM_FILES_DIR=\""            + _CMD(p.programFilesPath                        ) + "\"",
-                            "-dOPENSSL_PLAT=\""                 + _CMD(p.openSSLPlat                             ) + "\""];
+                            "-dOPENSSL_PLAT=\""                 + _CMD(p.openSSLPlat                             ) + "\"",
+                            "-dLZ4_DLL=\""                      + _CMD(p.LZ4DLL                                  ) + "\""];
 
                         // WiX compiling
                         b.pushRule(new WiXCompileBuildRule(
@@ -222,6 +225,7 @@ clean	Cleans intermediate and output files</example>
                                 BuildPath(p.buildPath, "wintun.msm"),
                                 BuildPath(p.openVPNPath, "bin", "libcrypto-1_1" + p.openSSLPlat + ".dll"),
                                 BuildPath(p.openVPNPath, "bin", "liblzo2-2.dll"),
+                                BuildPath(p.openVPNPath, "bin", p.LZ4DLL + ".dll"),
                                 BuildPath(p.openVPNPath, "bin", "libopenvpnmsica.dll"),
                                 BuildPath(p.openVPNPath, "bin", "libpkcs11-helper-1.dll"),
                                 BuildPath(p.openVPNPath, "bin", "libssl-1_1" + p.openSSLPlat + ".dll"),

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -623,6 +623,7 @@
                         <RemoveFile Id="nsis.openvpn.bin.libcrypto_1_1.dll" Property="NSIS.OPENVPN.BIN" Name="libcrypto-1_1$(var.OPENSSL_PLAT).dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.bin.libeay32.dll" Property="NSIS.OPENVPN.BIN" Name="libeay32.dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.bin.liblzo2_2.dll" Property="NSIS.OPENVPN.BIN" Name="liblzo2-2.dll" On="install"/>
+                        <RemoveFile Id="nsis.openvpn.bin.liblz4.dll" Property="NSIS.OPENVPN.BIN" Name="liblz4.dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.bin.libpkcs11_helper_1.dll" Property="NSIS.OPENVPN.BIN" Name="libpkcs11-helper-1.dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.bin.libssl_1_1.dll" Property="NSIS.OPENVPN.BIN" Name="libssl-1_1$(var.OPENSSL_PLAT).dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.bin.openssl.exe" Property="NSIS.OPENVPN.BIN" Name="openssl.exe" On="install"/>
@@ -665,6 +666,7 @@
                         <?if $(sys.BUILDARCH)="x64" ?>
                         <RemoveFile Id="nsis.openvpn.x86.bin.libeay32.dll" Property="NSIS.OPENVPN.X86.BIN" Name="libeay32.dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.x86.bin.liblzo2_2.dll" Property="NSIS.OPENVPN.X86.BIN" Name="liblzo2-2.dll" On="install"/>
+                        <RemoveFile Id="nsis.openvpn.x86.bin.liblz4.dll" Property="NSIS.OPENVPN.X86.BIN" Name="liblz4.dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.x86.bin.libpkcs11_helper_1.dll" Property="NSIS.OPENVPN.X86.BIN" Name="libpkcs11-helper-1.dll" On="install"/>
                         <RemoveFile Id="nsis.openvpn.x86.bin.openssl.exe" Property="NSIS.OPENVPN.X86.BIN" Name="openssl.exe" On="install"/>
                         <RemoveFile Id="nsis.openvpn.x86.bin.openvpn.exe" Property="NSIS.OPENVPN.X86.BIN" Name="openvpn.exe" On="install"/>
@@ -730,6 +732,9 @@
                         </Component>
                         <Component Id="bin.liblzo2_2.dll" Guid="{A1A057F0-235B-4F55-9A3A-CDA2112648F8}">
                             <File Name="liblzo2-2.dll" Source="!(bindpath.openvpn)bin\liblzo2-2.dll" Checksum="yes"/>
+                        </Component>
+                        <Component Id="bin.liblz4.dll" Guid="{A4DA1C46-8058-4AF2-8468-B1DF80BF670D}">
+                            <File Name="$(var.LZ4_DLL).dll" Source="!(bindpath.openvpn)bin\$(var.LZ4_DLL).dll" Checksum="yes"/>
                         </Component>
                         <Component Id="bin.libpkcs11_helper_1.dll" Guid="{62BB5466-934A-41FE-989B-9D0B6BD5151F}">
                             <File Name="libpkcs11-helper-1.dll" Source="!(bindpath.openvpn)bin\libpkcs11-helper-1.dll" Checksum="yes"/>
@@ -1457,6 +1462,7 @@
             <ComponentRef Id="license.txt"/>
             <ComponentRef Id="bin.libcrypto_1_1.dll"/>
             <ComponentRef Id="bin.liblzo2_2.dll"/>
+            <ComponentRef Id="bin.liblz4.dll"/>
             <ComponentRef Id="bin.libpkcs11_helper_1.dll"/>
             <ComponentRef Id="bin.libssl_1_1.dll"/>
             <ComponentRef Id="bin.openvpn.exe"/>

--- a/windows-nsis/openvpn.nsi
+++ b/windows-nsis/openvpn.nsi
@@ -129,6 +129,8 @@ LangString DESC_SecOpenSSLDLLs ${LANG_ENGLISH} "Install OpenSSL DLLs locally (ma
 
 LangString DESC_SecLZODLLs ${LANG_ENGLISH} "Install LZO DLLs locally (may be omitted if DLLs are already installed globally)."
 
+LangString DESC_SecLZ4DLLs ${LANG_ENGLISH} "Install LZ4 DLLs locally (may be omitted if DLLs are already installed globally)."
+
 LangString DESC_SecPKCS11DLLs ${LANG_ENGLISH} "Install PKCS#11 helper DLLs locally (may be omitted if DLLs are already installed globally)."
 
 LangString DESC_SecService ${LANG_ENGLISH} "Install the ${PACKAGE_NAME} service wrappers"
@@ -616,9 +618,9 @@ Section "-OpenSSL DLLs" SecOpenSSLDLLs
 	SetOverwrite on
 	SetOutPath "$INSTDIR\bin"
 	${If} ${RunningX64}
-		File /x liblzo2-2.dll /x libpkcs11-helper-1.dll "${OPENVPN_ROOT_X86_64}\bin\*.dll"
+		File /x liblzo2-2.dll /x libpkcs11-helper-1.dll /x liblz4.dll "${OPENVPN_ROOT_X86_64}\bin\*.dll"
 	${Else}
-		File /x liblzo2-2.dll /x libpkcs11-helper-1.dll "${OPENVPN_ROOT_I686}\bin\*.dll"
+		File /x liblzo2-2.dll /x libpkcs11-helper-1.dll /x liblz4.dll "${OPENVPN_ROOT_I686}\bin\*.dll"
 	${EndIf}
 
 SectionEnd
@@ -631,6 +633,18 @@ Section "-LZO DLLs" SecLZODLLs
 		File "${OPENVPN_ROOT_X86_64}\bin\liblzo2-2.dll"
 	${Else}
 		File "${OPENVPN_ROOT_I686}\bin\liblzo2-2.dll"
+	${EndIf}
+
+SectionEnd
+
+Section "-LZ4 DLLs" SecLZ4DLLs
+
+	SetOverwrite on
+	SetOutPath "$INSTDIR\bin"
+	${If} ${RunningX64}
+		File "${OPENVPN_ROOT_X86_64}\bin\liblz4.dll"
+	${Else}
+		File "${OPENVPN_ROOT_I686}\bin\liblz4.dll"
 	${EndIf}
 
 SectionEnd
@@ -695,6 +709,7 @@ ${EndIf}
 	!insertmacro SelectByParameter ${SecDisableSavePass} SELECT_DISABLE_SAVEPASS 0
 	!insertmacro SelectByParameter ${SecOpenSSLDLLs} SELECT_OPENSSLDLLS 1
 	!insertmacro SelectByParameter ${SecLZODLLs} SELECT_LZODLLS 1
+	!insertmacro SelectByParameter ${SecLZ4DLLs} SELECT_LZ4DLLS 1
 	!insertmacro SelectByParameter ${SecPKCS11DLLs} SELECT_PKCS11DLLS 1
 
 	!insertmacro MULTIUSER_INIT
@@ -788,6 +803,7 @@ SectionEnd
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecOpenSSLUtilities} $(DESC_SecOpenSSLUtilities)
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecOpenSSLDLLs} $(DESC_SecOpenSSLDLLs)
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecLZODLLs} $(DESC_SecLZODLLs)
+	!insertmacro MUI_DESCRIPTION_TEXT ${SecLZ4DLLs} $(DESC_SecLZ4DLLs)
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecPKCS11DLLs} $(DESC_SecPKCS11DLLs)
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecAddShortcuts} $(DESC_SecAddShortcuts)
 	!insertmacro MUI_DESCRIPTION_TEXT ${SecLaunchGUIOnLogon} $(DESC_SecLaunchGUIOnLogon)
@@ -859,6 +875,7 @@ Section "Uninstall"
 	Delete "$INSTDIR\bin\libeay32.dll"
 	Delete "$INSTDIR\bin\ssleay32.dll"
 	Delete "$INSTDIR\bin\liblzo2-2.dll"
+	Delete "$INSTDIR\bin\liblz4.dll"
 	Delete "$INSTDIR\bin\libpkcs11-helper-1.dll"
 	Delete "$INSTDIR\bin\libcrypto-1_1.dll"
 	Delete "$INSTDIR\bin\libcrypto-1_1-x64.dll"


### PR DESCRIPTION
To be consistent with other dependencies and to avoid
cludge in build system to support both mingw and msvc
openvpn binaries, build lz4 as a dynamic library.

To make this change ARM64-proof, MSI part includes
customization of lz4 dll name. MinGW builds it as "liblz4.dll",
but MSVC (will be used for ARM64) uses "lz4.dll".

Signed-off-by: Lev Stipakov <lev@openvpn.net>