### PR TITLE
generic/build: disable config autoload for OpenSSL

### DIFF
--- a/generic/build
+++ b/generic/build
@@ -198,6 +198,7 @@ build_dep() {
 			$(CHOST="${VIRTUAL_CHOST}" "${SCRIPTROOT}/gentoo.config-0.9.8") \
 			${CFLAGS} ${LDFLAGS} \
 			no-capieng \
+			no-autoload-config \
 			--openssldir=/etc/ssl \
 			--libdir=/lib \
 			${EXTRA_OPENSSL_CONFIG} \


### PR DESCRIPTION
On Windows cross-built OpenSSL loads config at path
c:\etc\ssl\openssl.conf, which is writable by non-admin user.

This could be a security risk, so disable config autoload.

Signed-off-by: Lev Stipakov <lev@openvpn.net>