### PR TITLE
Add a context menu item to .ovpn files for importing to the GUI

### DIFF
--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -1236,7 +1236,7 @@
                     Root="HKCR"
                     Key="$(var.PRODUCT_NAME)File\shell"
                     Type="string"
-                    Value="open"/>
+                    Value="import"/>
             </Component>
             <Component Id="reg.conf.icon" Guid="{9C61734E-69E5-4638-A400-2AD0517F5AEC}">
                 <RegistryValue
@@ -1265,6 +1265,20 @@
                     Key="$(var.PRODUCT_NAME)File\shell\run\command"
                     Type="string"
                     Value="&quot;[BINDIR]openvpn.exe&quot; &#45;&#45;pause-exit &#45;&#45;config &quot;%1&quot;"/>
+            </Component>
+            <Component Id="reg.conf.import" Guid="{16E0E503-0F36-4833-8D15-45FC7F8896E7}">
+                <RegistryValue
+                    Root="HKCR"
+                    Key="$(var.PRODUCT_NAME)File\shell\import"
+                    Type="string"
+                    Value="Import into $(var.PRODUCT_NAME)-GUI"/>
+            </Component>
+            <Component Id="reg.conf.import.command" Guid="{6C2D364F-FF04-4419-989D-FB007C992757}">
+                <RegistryValue
+                    Root="HKCR"
+                    Key="$(var.PRODUCT_NAME)File\shell\import\command"
+                    Type="string"
+                    Value="&quot;[BINDIR]openvpn-gui.exe&quot; &#45;&#45;command import &quot;%1&quot;"/>
             </Component>
             <Component Id="reg.openvpngui.startup" Guid="{073B129C-665D-4CF6-9E10-91A132C4B4BA}">
                 <RegistryKey
@@ -1484,7 +1498,6 @@
             <ComponentRef Id="reg.priority"/>
             <ComponentRef Id="reg.conf.extension"/>
             <ComponentRef Id="reg.conf.descr"/>
-            <ComponentRef Id="reg.conf.verb.default"/>
             <ComponentRef Id="reg.conf.icon"/>
             <ComponentRef Id="reg.conf.open.command"/>
             <ComponentRef Id="reg.conf.run"/>
@@ -1505,6 +1518,9 @@
                 <ComponentRef Id="shortcut.openvpn_gui.exe"/>
                 <ComponentRef Id="shortcut.openvpn_gui.exe.desktop"/>
                 <ComponentRef Id="reg.disable_save_passwords"/>
+                <ComponentRef Id="reg.conf.verb.default"/>
+                <ComponentRef Id="reg.conf.import"/>
+                <ComponentRef Id="reg.conf.import.command"/>
 
                 <Feature
                     Id="OpenVPN.GUI.OnLogon"


### PR DESCRIPTION
- Context menu: verb="import", description = "Import the VPN config"
 
- Also make "import" the default "verb". That is, double clicking on
  an ovpn file will import it instead of opening in an editor.
  When an .ovpn file is downloaded it can be automatically imported
  if the browser is set to open the file instead of saving it.

If the GUI is not installed, the "import" verb is not added
and "open" will automatically become the default. As per MSDN,
"open" has precedence over others when there is no explicit
default and no verb order is specified. This preserves the
current behaviour.

Signed-off-by: Selva Nair <selva.nair@gmail.com>