### PR TITLE
bump pkcs11-helper version and scheme

### DIFF
--- a/generic/build.vars
+++ b/generic/build.vars
@@ -2,19 +2,15 @@
 BUILD_VERSION="001"
 
 OPENSSL_VERSION="${OPENSSL_VERSION:-1.1.1k}"
-PKCS11_HELPER_VERSION="${PKCS11_HELPER_VERSION:-1.27.0}"
+PKCS11_HELPER_VERSION="${PKCS11_HELPER_VERSION:-1.28.0}"
 LZO_VERSION="${LZO_VERSION:-2.10}"
 LZ4_VERSION="${LZ4_VERSION:-1.9.3}"
 TAP_WINDOWS_VERSION="${TAP_WINDOWS_VERSION:-9.24.6}"
 OPENVPN_VERSION="${OPENVPN_VERSION:-2.5.4}"
 OPENVPN_GUI_VERSION="${OPENVPN_GUI_VERSION:-11}"
 
-# Needed because a variant of the version number is included in libpkcs11-helper
-# download paths. Basically 1.27.0 becomes 1.27, whereas 1.27.1 will remain as-is.
-PKCS11_HELPER_PATH=${PKCS11_HELPER_VERSION%%\.0}
-
 OPENSSL_URL="${OPENSSL_URL:-https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz}"
-PKCS11_HELPER_URL="${PKCS11_HELPER_URL:-https://github.com/OpenSC/pkcs11-helper/releases/download/pkcs11-helper-${PKCS11_HELPER_PATH}/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.bz2}"
+PKCS11_HELPER_URL="${PKCS11_HELPER_URL:-https://github.com/OpenSC/pkcs11-helper/releases/download/pkcs11-helper-${PKCS11_HELPER_VERSION}/pkcs11-helper-${PKCS11_HELPER_VERSION}.tar.gz}"
 TAP_WINDOWS_URL="${TAP_WINDOWS_URL:-http://build.openvpn.net/downloads/releases/tap-windows-${TAP_WINDOWS_VERSION}.zip}"
 LZO_URL="${LZO_URL:-http://www.oberhumer.com/opensource/lzo/download/lzo-${LZO_VERSION}.tar.gz}"
 LZ4_URL="${LZ4_URL:-https://github.com/lz4/lz4/archive/refs/tags/v${LZ4_VERSION}.tar.gz}"

--- a/generic/patches/pkcs11-helper-002-rename-interface-parameter.patch
+++ b/generic/patches/pkcs11-helper-002-rename-interface-parameter.patch
@@ -1,0 +1,32 @@
+From 0c2f862fe23dc6d2c0ca8432d1f6027c922c5a04 Mon Sep 17 00:00:00 2001
+From: Lev Stipakov <lev@openvpn.net>
+Date: Tue, 11 Jan 2022 14:24:45 +0200
+Subject: [PATCH] pkcs11.h: rename "interface" parameter
+
+"interface" is defined in cobaseapi.h as
+
+  #define interface __STRUCT__
+
+so use different name.
+
+Signed-off-by: Lev Stipakov <lev@openvpn.net>
+---
+ include/pkcs11-helper-1.0/pkcs11.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/pkcs11-helper-1.0/pkcs11.h b/include/pkcs11-helper-1.0/pkcs11.h
+index 85aa98e..7a7b958 100644
+--- a/include/pkcs11-helper-1.0/pkcs11.h
++++ b/include/pkcs11-helper-1.0/pkcs11.h
+@@ -1210,7 +1210,7 @@ _CK_DECLARE_FUNCTION (C_GetInterfaceList,
+ _CK_DECLARE_FUNCTION (C_GetInterface,
+ 		      (unsigned char *interface_name,
+ 		       struct ck_version *version,
+-		       struct ck_interface **interface,
++		       struct ck_interface **iface,
+ 		       ck_flags_t flags));
+ 
+ _CK_DECLARE_FUNCTION (C_LoginUser,
+-- 
+2.23.0.windows.1
+


### PR DESCRIPTION
`pkcs11-helper 1.28.0` got re-released with new [tag scheme](https://github.com/OpenSC/pkcs11-helper/issues/49) and archive compression method.

The path mismatch (generated from `tag`) should cease to be an issue in the future (possible [paradigm shift](https://github.com/OpenSC/pkcs11-helper/issues/29)).
Will have to see if change to archive compression type remains.