### PR TITLE
windows-msi: fixes and improvements to build-and-package.ps1

### DIFF
--- a/windows-msi/README.rst
+++ b/windows-msi/README.rst
@@ -65,6 +65,11 @@ To build and package::
     cd openvpn-build\windows-msi
     .\build-and-package.ps1 -basedir ..\..
 
+You can also define which OpenSSL vcpkg port to use:
+
+    .\build-and-package.ps1 -basedir ..\.. -openssl openssl
+    .\build-and-package.ps1 -basedir ..\.. -openssl openssl3
+
 If everything was set up correctly you should see three MSI packages in
 ``image`` subfolder, each signed and containing signed binaries.
 

--- a/windows-msi/build-and-package.ps1
+++ b/windows-msi/build-and-package.ps1
@@ -1,8 +1,14 @@
-param([string] $basedir)
+param(
+    # Must be a directory with openvpn, openvpn-gui, vcpkg and
+    # openvpn-build side by side
+    [string] $basedir,
+    # Version of OpenSSL port to use ("openssl" or "openssl3")
+    [string] $openssl = "openssl3"
+    )
 
 ### Preparations
 if(-not($basedir)) {
-	Write-Host "Usage: build-and-package.ps1 -basedir <basedir>"
+    Write-Host "Usage: build-and-package.ps1 -basedir <basedir> [-openssl] <openssl|openssl3>"
     exit 1
 }
 
@@ -13,12 +19,12 @@ $basedir_exists = Test-Path $basedir
 
 if ($basedir_exists -ne $True) {
     Write-Host "ERROR: directory ${basedir} does not exist!"
-	exit 1
+    exit 1
 }
 
 if ((Test-Path "${PSScriptRoot}/build-and-package-env.ps1") -ne $True) {
-	Write-Host "ERROR: configuration file (build-and-package-env.ps1I is missing"
-	exit 1
+    Write-Host "ERROR: configuration file (build-and-package-env.ps1) is missing"
+    exit 1
 }
 
 . "${PSScriptRoot}/build-and-package-env.ps1"
@@ -26,29 +32,38 @@ if ((Test-Path "${PSScriptRoot}/build-and-package-env.ps1") -ne $True) {
 # At the end of the build return to the directory we started from
 $cwd = Get-Location
 
-### Ensure that OpenVPN and OpenVPN GUI are using the latest dependencies
+### Ensure that we use latest "contrib" vcpkg ports
 cd "${basedir}\openvpn"
 & git.exe pull
 
 cd "${basedir}\vcpkg"
 & git.exe pull
 & .\bootstrap-vcpkg.bat
-& .\vcpkg.exe upgrade --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" --overlay-triplets "${basedir}\openvpn\contrib\vcpkg-triplets" --no-dry-run
 
+$architectures = @('x64','x86','arm64')
+ForEach ($arch in $architectures) {
+    # openssl:${arch}-windows is required for openvpn-gui builds
+    & .\vcpkg.exe --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" --overlay-triplets "${basedir}\openvpn\contrib\vcpkg-triplets" install --triplet "${arch}-windows-ovpn" lz4 lzo $openssl pkcs11-helper tap-windows6 "${openssl}:${arch}-windows"
+    # Our contrib ports may be more recent that what are available upstream, so
+    # ensure that those are taken into account when upgrading
+    & .\vcpkg.exe --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" --overlay-triplets  "${basedir}\openvpn\contrib\vcpkg-triplets" upgrade --no-dry-run
+    & .\vcpkg.exe integrate install
+}
 
 ### Build OpenVPN-GUI
-Copy-Item "${basedir}\openvpn-build\windows-msi\build-openvpn-gui.ps1" "${basedir}\openvpn-gui\"
 cd "${basedir}\openvpn-gui"
+& git.exe pull
+Copy-Item "${basedir}\openvpn-build\windows-msi\build-openvpn-gui.ps1" "${basedir}\openvpn-gui\"
 .\build-openvpn-gui.ps1
-
 
 ### Build OpenVPN
 cd "${basedir}\openvpn"
+& git.exe pull
 
 ForEach ($bat in "msbuild-x64.bat", "msbuild-x64_x86.bat", "msbuild-x64_arm64.bat") {
     If ((Test-Path $bat) -ne $True) {
-		Copy-Item "${basedir}\openvpn-build\windows-msi\${bat}" .
-	}
+        Copy-Item "${basedir}\openvpn-build\windows-msi\${bat}" .
+    }
 }
 
 & .\msbuild-x64.bat

--- a/windows-msi/build-and-package.ps1
+++ b/windows-msi/build-and-package.ps1
@@ -33,10 +33,10 @@ if ((Test-Path "${PSScriptRoot}/build-and-package-env.ps1") -ne $True) {
 $cwd = Get-Location
 
 ### Ensure that we use latest "contrib" vcpkg ports
-cd "${basedir}\openvpn"
+Set-Location "${basedir}\openvpn"
 & git.exe pull
 
-cd "${basedir}\vcpkg"
+Set-Location "${basedir}\vcpkg"
 & git.exe pull
 & .\bootstrap-vcpkg.bat
 
@@ -51,13 +51,13 @@ ForEach ($arch in $architectures) {
 }
 
 ### Build OpenVPN-GUI
-cd "${basedir}\openvpn-gui"
+Set-Location "${basedir}\openvpn-gui"
 & git.exe pull
 Copy-Item "${basedir}\openvpn-build\windows-msi\build-openvpn-gui.ps1" "${basedir}\openvpn-gui\"
 .\build-openvpn-gui.ps1
 
 ### Build OpenVPN
-cd "${basedir}\openvpn"
+Set-Location "${basedir}\openvpn"
 & git.exe pull
 
 ForEach ($bat in "msbuild-x64.bat", "msbuild-x64_x86.bat", "msbuild-x64_arm64.bat") {
@@ -71,17 +71,17 @@ ForEach ($bat in "msbuild-x64.bat", "msbuild-x64_x86.bat", "msbuild-x64_arm64.ba
 & .\msbuild-x64_arm64.bat
 
 ### Sign binaries
-cd "${basedir}\openvpn-build\windows-msi"
+Set-Location "${basedir}\openvpn-build\windows-msi"
 
 $Env:SignScript = "sign-openvpn.bat"
 & .\sign-binaries.bat
 
 ### Build MSI
-cd "${basedir}\openvpn-build\windows-msi"
+Set-Location "${basedir}\openvpn-build\windows-msi"
 & cscript.exe build.wsf msi
 
 ### Sign MSI
 $Env:SignScript = "sign-msi.bat"
 & .\sign-binaries.bat
 
-cd $cwd
+Set-Location $cwd

--- a/windows-msi/build-and-package.ps1
+++ b/windows-msi/build-and-package.ps1
@@ -43,10 +43,20 @@ Set-Location "${basedir}\vcpkg"
 $architectures = @('x64','x86','arm64')
 ForEach ($arch in $architectures) {
     # openssl:${arch}-windows is required for openvpn-gui builds
-    & .\vcpkg.exe --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" --overlay-triplets "${basedir}\openvpn\contrib\vcpkg-triplets" install --triplet "${arch}-windows-ovpn" lz4 lzo $openssl pkcs11-helper tap-windows6 "${openssl}:${arch}-windows"
+    & .\vcpkg.exe `
+        --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" `
+        --overlay-ports "${basedir}\openvpn-build\windows-msi\vcpkg-ports" `
+        --overlay-triplets "${basedir}\openvpn\contrib\vcpkg-triplets" `
+        install --triplet "${arch}-windows-ovpn" lz4 lzo $openssl pkcs11-helper tap-windows6 "${openssl}:${arch}-windows"
+
     # Our contrib ports may be more recent that what are available upstream, so
     # ensure that those are taken into account when upgrading
-    & .\vcpkg.exe --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" --overlay-triplets  "${basedir}\openvpn\contrib\vcpkg-triplets" upgrade --no-dry-run
+    & .\vcpkg.exe `
+        --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" `
+        --overlay-ports "${basedir}\openvpn-build\windows-msi\vcpkg-ports" `
+        --overlay-triplets  "${basedir}\openvpn\contrib\vcpkg-triplets" `
+        upgrade --no-dry-run
+
     & .\vcpkg.exe integrate install
 }
 

--- a/windows-msi/vcpkg-ports/readme.txt
+++ b/windows-msi/vcpkg-ports/readme.txt
@@ -1,0 +1,2 @@
+This is the directory for vcpkg port overlays. It could be used when official vcpkg repo hasn't yet
+contained the latest version of ports, like openssl.


### PR DESCRIPTION
- Support openssl 1.1.1 and 3.x builds
- Ensure that all dependencies are installed, upgraded and
  integrated in case something in provisioning failed or
  dependencies have changed
- Reorder some commands so they make more sense

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>