### PR TITLE
windows-msi: adapt to manifest and presets changes in openvpn and ope…

### DIFF
--- a/windows-msi/README.rst
+++ b/windows-msi/README.rst
@@ -48,7 +48,7 @@ This command will print out the certificate thumbprint which you'll need later.
 Now create a config file, ``build-and-package-env.ps1``, next to ``build-and-package.ps1``::
     
     # Used by build scripts build-and-package.sh calls
-    $Env:CMAKE_TOOLCHAIN_FILE = "${basedir}\vcpkg\scripts\buildsystems\vcpkg.cmake" 
+    $Env:VCPKG_ROOT = "${basedir}\vcpkg" 
     $Env:CMAKE = "C:\\Program Files\\CMake\\bin\\cmake.exe"
     $Env:ManifestCertificateThumbprint = "cert thumbprint" 
     $Env:ManifestTimestampRFC3161Url = "http://timestamp.digicert.com" 

--- a/windows-msi/build-and-package-env-sample.ps1
+++ b/windows-msi/build-and-package-env-sample.ps1
@@ -1,5 +1,5 @@
 # Used by build scripts build-and-package.sh calls
-$Env:CMAKE_TOOLCHAIN_FILE = "${basedir}\vcpkg\scripts\buildsystems\vcpkg.cmake"
+$Env:VCPKG_ROOT = "${basedir}\vcpkg"
 $Env:CMAKE = "C:\\Program Files\\CMake\\bin\\cmake.exe"
 $Env:ManifestCertificateThumbprint = "thumbprint"
 $Env:ManifestTimestampRFC3161Url = "http://timestamp.digicert.com"

--- a/windows-msi/build-and-package.ps1
+++ b/windows-msi/build-and-package.ps1
@@ -2,13 +2,13 @@ param(
     # Must be a directory with openvpn, openvpn-gui, vcpkg and
     # openvpn-build side by side
     [string] $basedir,
-    # Version of OpenSSL port to use ("openssl" or "openssl3")
-    [string] $openssl = "openssl3"
+    # Version of OpenSSL port to use ("ossl1.1.1" or "ossl3")
+    [string] $ossl = "ossl3"
     )
 
 ### Preparations
 if(-not($basedir)) {
-    Write-Host "Usage: build-and-package.ps1 -basedir <basedir> [-openssl] <openssl|openssl3>"
+    Write-Host "Usage: build-and-package.ps1 -basedir <basedir> [-openssl] <ossl1.1.1|ossl3>"
     exit 1
 }
 
@@ -39,26 +39,7 @@ Set-Location "${basedir}\openvpn"
 Set-Location "${basedir}\vcpkg"
 & git.exe pull
 & .\bootstrap-vcpkg.bat
-
-$architectures = @('x64','x86','arm64')
-ForEach ($arch in $architectures) {
-    # openssl:${arch}-windows is required for openvpn-gui builds
-    & .\vcpkg.exe `
-        --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" `
-        --overlay-ports "${basedir}\openvpn-build\windows-msi\vcpkg-ports" `
-        --overlay-triplets "${basedir}\openvpn\contrib\vcpkg-triplets" `
-        install --triplet "${arch}-windows-ovpn" lz4 lzo $openssl pkcs11-helper tap-windows6 "${openssl}:${arch}-windows"
-
-    # Our contrib ports may be more recent that what are available upstream, so
-    # ensure that those are taken into account when upgrading
-    & .\vcpkg.exe `
-        --overlay-ports "${basedir}\openvpn\contrib\vcpkg-ports" `
-        --overlay-ports "${basedir}\openvpn-build\windows-msi\vcpkg-ports" `
-        --overlay-triplets  "${basedir}\openvpn\contrib\vcpkg-triplets" `
-        upgrade --no-dry-run
-
-    & .\vcpkg.exe integrate install
-}
+& .\vcpkg.exe integrate install
 
 ### Build OpenVPN-GUI
 Set-Location "${basedir}\openvpn-gui"

--- a/windows-msi/build-openvpn-gui.ps1
+++ b/windows-msi/build-openvpn-gui.ps1
@@ -2,30 +2,21 @@
 #
 # Example of setting the environment variables:
 #
-# $Env:CMAKE_TOOLCHAIN_FILE = "C:\Users\john\vcpkg\scripts\buildsystems\vcpkg.cmake"
+# $Env:VCPKG_ROOT = "C:\Users\john\vcpkg"
 # $Env:CMAKE = "C:\Program Files\CMake\bin\cmake.exe"
 
 $CWD = Get-Location
 $CMAKE=$Env:CMAKE
-$CMAKE_TOOLCHAIN_FILE=$Env:CMAKE_TOOLCHAIN_FILE
+$OSSL=$Env:OSSL
 
 # Enable running this script from anywhere
-cd $PSScriptRoot
+Set-Location $PSScriptRoot
 
-# Architecture names taken from here:
-#
-# https://docs.microsoft.com/en-us/cpp/build/cmake-presets-vs?view=msvc-160
-"x64", "arm64", "Win32" | ForEach  {
+"x64", "arm64", "x86" | ForEach  {
 	$platform = $_
     Write-Host "Building openvpn-gui ${platform}"
-    if ( ( Test-Path "build_${platform}" ) -eq $False )
-	{
-        mkdir build_$platform
-	}
-    cd build_$platform
-    & "$CMAKE" -A $platform -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" ..
-    & "$CMAKE" --build . --config Release
-    cd $PSScriptRoot
+    & "$CMAKE" -S . --preset ${platform}-release-${OSSL}
+    & "$CMAKE" --build --preset ${platform}-release-${OSSL}
 }
 
-cd $CWD
+Set-Location $CWD

--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -59,8 +59,8 @@ clean	Cleans intermediate and output files</example>
                 "x86": {
                     "buildPath": BuildPath(buildPath, "x86"),
                     "openVPNBinPath": BuildPath(depsPath, "openvpn", "Win32-Output", "Release"),
-                    "openVPNGuiBinPath": BuildPath(depsPath, "openvpn-gui", "build_Win32", "Release"),
-                    "openSSLBinPath": BuildPath(depsPath, "vcpkg", "installed", "x86-windows-ovpn", "tools", "openssl"),
+                    "openVPNGuiBinPath": BuildPath(depsPath, "openvpn-gui", "out", "build", "x86-release-ossl3"),
+                    "openSSLBinPath": BuildPath(depsPath, "openvpn", "src", "openvpn", "vcpkg_installed", "x86-windows-ovpn", "x86-windows-ovpn", "tools", "openssl"),
                     "programFilesPath": "ProgramFilesFolder",
                     "openSSLPlat": "",
                     "wixPlat": "x86",
@@ -70,8 +70,8 @@ clean	Cleans intermediate and output files</example>
                 "amd64": {
                     "buildPath": BuildPath(buildPath, "amd64"),
                     "openVPNBinPath": BuildPath(depsPath, "openvpn", "x64-Output", "Release"),
-                    "openVPNGuiBinPath": BuildPath(depsPath, "openvpn-gui", "build_x64", "Release"),
-                    "openSSLBinPath": BuildPath(depsPath, "vcpkg", "installed", "x64-windows-ovpn", "tools", "openssl"),
+                    "openVPNGuiBinPath": BuildPath(depsPath, "openvpn-gui", "out", "build", "x64-release-ossl3"),
+                    "openSSLBinPath": BuildPath(depsPath, "openvpn", "src", "openvpn", "vcpkg_installed", "x64-windows-ovpn", "x64-windows-ovpn", "tools", "openssl"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-x64",
                     "wixPlat": "x64",
@@ -80,9 +80,9 @@ clean	Cleans intermediate and output files</example>
 
                 "arm64": {
                     "buildPath": BuildPath(buildPath, "arm64"),
-                    "openVPNGuiBinPath": BuildPath(depsPath, "openvpn-gui", "build_arm64", "Release"),
                     "openVPNBinPath": BuildPath(depsPath, "openvpn", "ARM64-Output", "Release"),
-                    "openSSLBinPath": BuildPath(depsPath, "vcpkg", "installed", "arm64-windows-ovpn", "tools", "openssl"),
+                    "openVPNGuiBinPath": BuildPath(depsPath, "openvpn-gui", "out", "build", "arm64-release-ossl3"),
+                    "openSSLBinPath": BuildPath(depsPath, "openvpn", "src", "openvpn", "vcpkg_installed", "arm64-windows-ovpn", "arm64-windows-ovpn", "tools", "openssl"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-arm64",
                     "wixPlat": "arm64",

--- a/windows-msi/sign-openvpn.bat
+++ b/windows-msi/sign-openvpn.bat
@@ -9,6 +9,8 @@ rem
 rem Set `%ManifestTimestampRFC3161Url%` to URL of your code signing cerificate provider's
 rem RFC3161-compliant web service.
 rem
+rem Set `%OSSL%` to either `ossl3` or `ossl1.1.1`.
+rem
 rem Run this script before packaging.
 
 signtool.exe sign /sha1 "%ManifestCertificateThumbprint%" /fd sha256 /tr "%ManifestTimestampRFC3161Url%" /td sha256^
@@ -18,9 +20,9 @@ signtool.exe sign /sha1 "%ManifestCertificateThumbprint%" /fd sha256 /tr "%Manif
  ..\..\openvpn\Win32-Output\Release\*.dll^
  ..\..\openvpn\ARM64-Output\Release\*.exe^
  ..\..\openvpn\ARM64-Output\Release\*.dll^
- ..\..\vcpkg\installed\x64-windows-ovpn\tools\openssl\openssl.exe^
- ..\..\vcpkg\installed\x86-windows-ovpn\tools\openssl\openssl.exe^
- ..\..\vcpkg\installed\arm64-windows-ovpn\tools\openssl\openssl.exe^
- ..\..\openvpn-gui\build_x64\Release\openvpn-gui.exe^
- ..\..\openvpn-gui\build_Win32\Release\openvpn-gui.exe^
- ..\..\openvpn-gui\build_arm64\Release\openvpn-gui.exe
+ ..\..\openvpn\src\openvpn\vcpkg_installed\x64-windows-ovpn\x64-windows-ovpn\tools\openssl\openssl.exe^
+ ..\..\openvpn\src\openvpn\vcpkg_installed\arm64-windows-ovpn\arm64-windows-ovpn\tools\openssl\openssl.exe^
+ ..\..\openvpn\src\openvpn\vcpkg_installed\x86-windows-ovpn\x86-windows-ovpn\tools\openssl\openssl.exe^
+ ..\..\openvpn-gui\out\build\x64-release-"%OSSL%"\openvpn-gui.exe^
+ ..\..\openvpn-gui\out\build\arm64-release-"%OSSL%"\openvpn-gui.exe^
+ ..\..\openvpn-gui\out\build\x86-release-"%OSSL%"\openvpn-gui.exe


### PR DESCRIPTION
…nvpn-gui

With manifest, it is no longer needed to install dependencies separately, they're
installed as part of build process.

With presets, output directories are already set, no need to create build_<platform>.
Also CMAKE_TOOLCHAIN_FILE is set by presets from VCPKG_ROOT variable.

Signed-off-by: Lev Stipakov <lev@openvpn.net>