### PR TITLE
GitHub Actions: use longer delay with port knocking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
         run: find -name '*.msi' -printf "%p\n" | while read f; do mv $f $(dirname $f).msi; rm -rf $(dirname $f); done
 
       - name: Knock ports on remote
-        run: knock -d 2 ${{ secrets.MSI_UPLOAD_REMOTE_HOST }} ${{ secrets.MSI_UPLOAD_REMOTE_KNOCK_SEQUENCE }} ; sleep 1
+        run: knock -d 500 ${{ secrets.MSI_UPLOAD_REMOTE_HOST }} ${{ secrets.MSI_UPLOAD_REMOTE_KNOCK_SEQUENCE }} ; sleep 1
 
       - name: Copy MSI to remote
         uses: garygrossgarten/github-action-scp@release


### PR DESCRIPTION
Without delay or with small delay packets may arrive
in different order or blocked because they could be mistaken
for port scan. Use 500ms delay to try to avoid it.

Signed-off-by: Lev Stipakov <lev@openvpn.net>