### PR TITLE
OpenVPNService: install by default and keep previous state

### DIFF
--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -69,6 +69,11 @@
         -->
         <Property Id="REINSTALLMODE" Value="amus"/>
 
+        <Binary Id="Service.js" SourceFile="script\Service.js"/>
+
+        <CustomAction Id="CheckOpenVPNServiceStatus" BinaryKey="Service.js" JScriptCall="CheckOpenVPNServiceStatus" />
+        <CustomAction Id="ConfigureOpenVPNService"  BinaryKey="Service.js" JScriptCall="ConfigureOpenVPNService" Execute="deferred" Impersonate="no" />
+
         <!--
             Detect system information
         -->
@@ -78,9 +83,13 @@
         </InstallUISequence>
         <InstallExecuteSequence>
             <Custom Action="FindSystemInfo" After="FindRelatedProducts"/>
+            <Custom Action="CheckOpenVPNServiceStatus" After="ProcessComponents"/>
+            <Custom Action="ConfigureOpenVPNService" After="StartServices">NOT Installed</Custom>
         </InstallExecuteSequence>
         <UI>
             <ProgressText Action="FindSystemInfo">Detecting system information</ProgressText>
+            <ProgressText Action="CheckOpenVPNServiceStatus">Checking status of OpenVPNService</ProgressText>
+            <ProgressText Action="ConfigureOpenVPNService">Configuring OpenVPNService</ProgressText>
         </UI>
 
         <Property Id="TAPWINDOWS6ADAPTERS" Secure="yes"/>
@@ -771,14 +780,14 @@
                                 Id="OpenVPNService"
                                 Name="OpenVPNService"
                                 Stop="both"
-                                Start="install"
                                 Remove="uninstall"/>
                             <ServiceInstall
                                 Id="OpenVPNService"
                                 Name="OpenVPNService"
                                 DisplayName="OpenVPNService"
+                                Description="Responsible for automatic start of OpenVPN instances."
                                 Type="ownProcess"
-                                Start="auto"
+                                Start="disabled"
                                 ErrorControl="normal">
                                 <ServiceDependency Id="Dhcp"/>
                             </ServiceInstall>
@@ -794,7 +803,7 @@
                         </Component>
                         <!-- Move auto-start config files from configuration folder to auto-start configuration folder on update from non-auto-start aware installations. -->
                         <Component Id="config.Where_are_my_config_files.txt" Guid="{2DFEDF05-F41E-4EB0-A90A-DC76A261E444}">
-                            <Condition><![CDATA[OPENVPNSERVICE AND CONFIGDIRREG AND NOT CONFIGAUTODIRREG]]></Condition>
+                            <Condition><![CDATA[CONFIGDIRREG AND NOT CONFIGAUTODIRREG]]></Condition>
                             <File Name="Where are my config files.txt" Source="!(bindpath.build)Where are my config files.txt"/>
                             <CopyFile
                                 Id="config_auto"
@@ -1531,11 +1540,10 @@
             <Feature
                 Id="OpenVPN.Service"
                 Title="$(var.PRODUCT_NAME) Service"
-                Description="Service wrappers"
-                Level="3"
+                Description="Responsible for automatic start of OpenVPN instances"
+                Level="2"
                 ConfigurableDirectory="PRODUCTDIR"
                 AllowAdvertise="no">
-                <Condition Level="1"><![CDATA[NETFRAMEWORK40FULL AND OPENVPNSERVICE AND CONFIGDIRREG AND NOT CONFIGAUTODIRREG]]></Condition>
                 <Condition Level="0"><![CDATA[NOT NETFRAMEWORK40FULL AND NOT Installed]]></Condition>
                 <ComponentRef Id="bin.openvpnserv2.exe"/>
                 <ComponentRef Id="config.Where_are_my_config_files.txt"/>

--- a/windows-msi/script/Service.js
+++ b/windows-msi/script/Service.js
@@ -1,0 +1,61 @@
+/*
+ *  openvpn-build — OpenVPN packaging
+ *
+ *  Copyright (C) 2022 Lev Stipakov <lev@openvpn.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+var _serviceName = "OpenVPNService";
+
+function IsServiceExist() {
+    var wmi = GetObject("winmgmts://./root/cimv2");
+    var svcs = wmi.ExecQuery("Select * from Win32_Service where Name = '" + _serviceName + "'");
+    return svcs.Count > 0;
+}
+
+function CheckOpenVPNServiceStatus() {
+    if (!IsServiceExist())
+        return;
+
+    var wmi = GetObject("winmgmts://./root/cimv2");
+    var srv = wmi.Get("Win32_Service.Name='" + _serviceName + "'");
+    var startMode = srv.StartMode.toLowerCase();
+    if ((startMode != "auto") && (startMode != "disabled"))
+        startMode = "demand";
+    var started = srv.Started;
+    Session.Property("ConfigureOpenVPNService") = [startMode, started].join(",");
+}
+
+function ConfigureOpenVPNService() {
+    if (!IsServiceExist())
+        return;
+
+    var startMode = "";
+    var started = false;
+    var val = Session.Property("CustomActionData");
+    if (val == "") {
+        // this likely means new install
+        startMode = "demand";
+    } else {
+        arr = val.split(",");
+        startMode = arr[0];
+        started = arr[1] == "true";
+    }
+    var wsh = new ActiveXObject("WScript.Shell");
+    wsh.Run("sc config " + _serviceName + " start= " + startMode, 0, true);
+    if (started) {
+        wsh.Run("sc start " + _serviceName, 0, true);
+    }
+}


### PR DESCRIPTION
As we don't support "Modify" action, adding OpenVPNService
is problematic since it requires uninstall and reinstall.

Install it by default. For clean install, use "Manual"
start mode and doesn't start it. For upgrade, preserve existing
configuration - for example if start mode was "automatic" and service
was started - the same will apply for the new installation.

This allows to remove code from openvpnmsica.dll which
reads service status, but doesn't apply it to the new installation.

Signed-off-by: Lev Stipakov <lev@openvpn.net>