### PR TITLE
windows-msi/version.m4: Update Easy-RSA v3.1.0 to v3.1.1

### DIFF
--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -24,8 +24,10 @@ dnl OpenVPNServ2.exe binary
 define([OPENVPNSERV2_URL], [http://build.openvpn.net/downloads/releases/openvpnserv2-1.4.0.1.exe])
 
 dnl Easy RSA binaries (URL to .tar.gz file containing "easy-rsa-[EASYRSA_VERSION]" folder with Easy RSA)
-define([EASYRSA_VERSION], [3.1.0])
-define([EASYRSA_URL],     [https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.0/EasyRSA-3.1.0-win64.zip])
+dnl EasyRSA win64.zip downloaded here only contains 32bit *nix style binaries from distro/windows/bin.
+dnl The downloaded zip file does not contain OpenSSL binaries, which would be 64bit.
+define([EASYRSA_VERSION], [3.1.1])
+define([EASYRSA_URL],     [https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.1/EasyRSA-3.1.1-win64.zip])
 
 
 dnl ============================================================


### PR DESCRIPTION
Update download source to: OpenVPN/easy-rsa Release v3.1.1

Add comments to clarify that the 64bit version of Easy-RSA is suitable for OpenVPN Windows Installer for both 32bit and 64bit.

For the record:
The only part of Easy-RSA which is 64bit is the pre-built OpenSSL binary. The Easy-RSA for Windows zip files, distributed from github, do not contain any OpenSSL binaries.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>