### PR TITLE
Add t_client Windows tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [openvpn-commit]
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkoutjobs:
+
 jobs:
   msvc:
     strategy:
@@ -96,11 +100,60 @@ jobs:
           name: openvpn-master-${{ env.DATETIME }}-${{ env.OPENVPN_COMMIT }}-${{ matrix.arch }}
           path: ${{ github.workspace }}\openvpn-build\windows-msi\image\*-${{ matrix.arch }}.msi
 
-  upload_msis:
+  run_tclient_tests:
+    name: Run t_client tests on AWS
     needs: msvc
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'openvpn/openvpn-build' && github.event_name != 'pull_request' }}
+    env:
+      AWS_REGION : "eu-west-1"
+
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::217307881341:role/GitHubActions
+          role-session-name: githubactions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Clone openvpn-windows-test repo
+        uses: actions/checkout@v3
+        with:
+          repository: openvpn/openvpn-windows-test
+          ref: master
+          path: openvpn-windows-test
+
+      - name: Install SSH key for tclient host
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY_FOR_TCLIENT_HOST }}
+          known_hosts: unnecessary
+
+      - name: Get artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: msi
+
+      - name: Run AWS test
+        working-directory: openvpn-windows-test
+        shell: pwsh
+        run: |
+          Install-Module -Name AWS.Tools.Installer -Force
+          Install-AWSToolsModule AWS.Tools.EC2 -Force
+          .\Start-AWSTest.ps1 -SSH_KEY ~/.ssh/id_rsa -MSI_PATH $(Get-ChildItem ../msi/*-amd64/*.msi | select -ExpandProperty FullName)
+
+      - name: Archive openvpn logs
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: t_client_openvpn_logs
+          path: openvpn-windows-test/openvpn-logs.zip
+
+  upload_msis:
+    needs: run_tclient_tests
     name: upload-msis
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'openvpn/openvpn-build' }}
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' && github.repository == 'openvpn/openvpn-build' }}
 
     steps:
       - name: Install knock


### PR DESCRIPTION
After building MSI, run t_client tests from
openvpn-windows-test repo.

This launches Windows 2022 EC2 instance,
copies and installs 64bit MSI and runs various
connection tests agains existing backend infrastructure.

See

https://github.com/OpenVPN/openvpn-windows-test/blob/master/Start-LocalTest.ps1

for tests details.

Signed-off-by: Lev Stipakov <lev@openvpn.net>