### PR TITLE
Prevent concurrent run of t_client tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,6 +103,7 @@ jobs:
   run_tclient_tests:
     name: Run t_client tests on AWS
     needs: msvc
+    concurrency: aws_tclient_tests
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'openvpn/openvpn-build' && github.event_name != 'pull_request' }}
     env:


### PR DESCRIPTION
Test backend doesn't allow multiple connections with the same CN, so prevent running t_client aws tests in parallel.

Signed-off-by: Lev Stipakov <lev@openvpn.net>