### PR TITLE
Revert tap-windows to 9.24.6

### DIFF
--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -3,9 +3,9 @@ dnl Downloadables
 dnl ============================================================
 
 dnl TAP-Windows binaries
-define([PRODUCT_TAP_WIN_URL_x86],      [https://build.openvpn.net/downloads/releases/tap-windows-9.24.8-I601-i386.msm])
-define([PRODUCT_TAP_WIN_URL_amd64],    [https://build.openvpn.net/downloads/releases/tap-windows-9.24.8-I601-amd64.msm])
-define([PRODUCT_TAP_WIN_URL_arm64],    [https://build.openvpn.net/downloads/releases/tap-windows-9.24.8-I601-arm64.msm])
+define([PRODUCT_TAP_WIN_URL_x86],      [https://build.openvpn.net/downloads/releases/tap-windows-9.24.6-I601-i386.msm])
+define([PRODUCT_TAP_WIN_URL_amd64],    [https://build.openvpn.net/downloads/releases/tap-windows-9.24.6-I601-amd64.msm])
+define([PRODUCT_TAP_WIN_URL_arm64],    [https://build.openvpn.net/downloads/releases/tap-windows-9.24.6-I601-arm64.msm])
 define([PRODUCT_TAP_WIN_COMPONENT_ID], [tap0901])
 define([PRODUCT_TAP_WIN_NAME],         [TAP-Windows])
 


### PR DESCRIPTION
MSFT has deprecated cross-signing and therefore
Windows 7 driver is signed incorrectly. While we
settle the signing issue, revert driver to 9.24.6.

Signed-off-by: Lev Stipakov <lev@openvpn.net>