### PR TITLE
Write actual install path into openvpn-plap-install.reg

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -265,6 +265,7 @@ clean	Cleans intermediate and output files</example>
                                 BuildPath("artwork", "warning.ico"),
                                 BuildPath("doc", "LicenseAgreement.rtf"),
                                 BuildPath("script", "ActiveSetupCA.js"),
+                                BuildPath("script", "PlapReg.js"),
                                 BuildPath(p.buildPath, "license.txt"),
                                 BuildPath(p.buildPath, "tap-windows6.msm"),
                                 BuildPath(p.buildPath, "wintun.msm"),

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -82,6 +82,10 @@
         <Property Id="REINSTALLMODE" Value="amus"/>
 
         <Binary Id="Service.js" SourceFile="script\Service.js"/>
+        <Binary Id="PlapReg.js" SourceFile="script\PlapReg.js"/>
+
+        <CustomAction Id="GetInstallDir" BinaryKey="PlapReg.js" JScriptCall="GetInstallDir" />
+        <CustomAction Id="UpdatePlapReg" BinaryKey="PlapReg.js" JScriptCall="UpdatePlapReg" Execute="deferred" Impersonate="no" />
 
         <CustomAction Id="CheckOpenVPNServiceStatus" BinaryKey="Service.js" JScriptCall="CheckOpenVPNServiceStatus" />
         <CustomAction Id="ConfigureOpenVPNService"  BinaryKey="Service.js" JScriptCall="ConfigureOpenVPNService" Execute="deferred" Impersonate="no" />
@@ -97,6 +101,8 @@
             <Custom Action="FindSystemInfo" After="FindRelatedProducts"/>
             <Custom Action="CheckOpenVPNServiceStatus" After="ProcessComponents"/>
             <Custom Action="ConfigureOpenVPNService" After="StartServices">NOT Installed</Custom>
+            <Custom Action="GetInstallDir" After="FindRelatedProducts"/>
+            <Custom Action="UpdatePlapReg" After="InstallFiles"/>
         </InstallExecuteSequence>
         <UI>
             <ProgressText Action="FindSystemInfo">Detecting system information</ProgressText>

--- a/windows-msi/script/PlapReg.js
+++ b/windows-msi/script/PlapReg.js
@@ -1,0 +1,72 @@
+/*
+ *  openvpn-build — OpenVPN packaging
+ *
+ *  Copyright (C) 2022 Lev Stipakov <lev@openvpn.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+function GetInstallDir() {
+    var installPath = Session.Property("PRODUCTDIR");
+    installPath = installPath.replace(new RegExp(/\\/g), "\\\\");
+    Session.Property("UpdatePlapReg") = installPath;
+}
+
+function UpdatePlapReg() {
+    var installPath = Session.Property("CustomActionData");
+    if (installPath == "") // uninstall
+        return;
+
+    var binPath = installPath + "bin\\\\";
+    var oldFile = binPath + "openvpn-plap-install.reg";
+    var newFile = binPath + "openvpn-plap-install-new.reg";
+    var plapDll = binPath + "libopenvpn_plap.dll";
+
+    var fso = new ActiveXObject("Scripting.FileSystemObject");
+
+    try {
+        // regex to match @="C:\\Program Files\\OpenVPN\\bin\\libopenvpn_plap.dll"
+        var r = new RegExp("^@=\"\\w:")
+
+        var fso = new ActiveXObject("Scripting.FileSystemObject");
+        if (!fso.FileExists(oldFile))
+            return; // feature not installed
+
+        var os = fso.OpenTextFile(oldFile);
+        var ns = fso.CreateTextFile(newFile);
+
+        while (!os.AtEndOfStream) {
+            var line = new String(os.ReadLine());
+            if (line.match(r)) {
+                line = "@=\"" + plapDll + "\"";
+            }
+            ns.WriteLine(line);
+        }
+
+        os.Close();
+        ns.Close();
+
+        fso.DeleteFile(oldFile);
+        fso.MoveFile(newFile, oldFile);
+    }
+    catch (err) {
+        // something wrong, but this is not super critical
+    }
+    finally {
+        // cleanup
+        if (fso.FileExists(newFile)) {
+            fso.DeleteFile(newFile);
+        }
+    }
+}


### PR DESCRIPTION
openvpn-plap-install.reg has install path hardcoded, which breaks when OpenVPN is installed to non-default location.

Add 2 custom action:

 - GetInstallDir to get install path

 - UpdatePlapReg to update openvpn-plap-install.reg

 Second action is deferred and runs under elevated privileges,
 so it is able to modify files at installation path.

Signed-off-by: Lev Stipakov <lev@openvpn.net>