### PR TITLE
msvc: update to Visual Studio 2022

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       WIX: ${{ github.workspace }}\wix\
 
     name: 'openvpn-build'
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
       - name: Checkout openvpn-build


### PR DESCRIPTION
The latest Windows runner has Visual Studio 2022 installed.

Signed-off-by: Lev Stipakov <lev@openvpn.net>