### PR TITLE
Start service by default

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -266,6 +266,7 @@ clean	Cleans intermediate and output files</example>
                                 BuildPath("doc", "LicenseAgreement.rtf"),
                                 BuildPath("script", "ActiveSetupCA.js"),
                                 BuildPath("script", "PlapReg.js"),
+                                BuildPath("script", "Service.js"),
                                 BuildPath(p.buildPath, "license.txt"),
                                 BuildPath(p.buildPath, "tap-windows6.msm"),
                                 BuildPath(p.buildPath, "wintun.msm"),

--- a/windows-msi/script/Service.js
+++ b/windows-msi/script/Service.js
@@ -43,19 +43,20 @@ function ConfigureOpenVPNService() {
         return;
 
     var startMode = "";
-    var started = false;
+    var needsStart = false;
     var val = Session.Property("CustomActionData");
     if (val == "") {
         // this likely means new install
-        startMode = "demand";
+        startMode = "auto";
+        needsStart = true;
     } else {
         arr = val.split(",");
         startMode = arr[0];
-        started = arr[1] == "true";
+        needsStart = arr[1] == "true";
     }
     var wsh = new ActiveXObject("WScript.Shell");
     wsh.Run("sc config " + _serviceName + " start= " + startMode, 0, true);
-    if (started) {
+    if (needsStart) {
         wsh.Run("sc start " + _serviceName, 0, true);
     }
 }


### PR DESCRIPTION
Instead of using "manual" start type,
start service by default for clean installs.

Signed-off-by: Lev Stipakov <lev@openvpn.net>