### PR TITLE
Fix line continuation issue in sign-openvpn.bat

### DIFF
--- a/windows-msi/sign-openvpn.bat
+++ b/windows-msi/sign-openvpn.bat
@@ -27,5 +27,5 @@ signtool.exe sign /sha1 "%ManifestCertificateThumbprint%" /fd sha256 /tr "%Manif
  ..\src\openvpn-gui\out\build\x64-release-"%OSSL%"\*.dll^
  ..\src\openvpn-gui\out\build\arm64-release-"%OSSL%"\openvpn-gui.exe^
  ..\src\openvpn-gui\out\build\arm64-release-"%OSSL%"\*.dll^
- ..\src\openvpn-gui\out\build\x86-release-"%OSSL%"\openvpn-gui.exe
- ..\src\openvpn-gui\out\build\x86-release-"%OSSL%"\*.dll^
+ ..\src\openvpn-gui\out\build\x86-release-"%OSSL%"\openvpn-gui.exe^
+ ..\src\openvpn-gui\out\build\x86-release-"%OSSL%"\*.dll


### PR DESCRIPTION
The x86 DLLs of `openvpn-gui` in `v2.6_rc1` did NOT get signed due to this.
Arguments to `signtool` stopped after `openvpn-gui.exe`.

Not sure what happens when the script tries to execute the (PLAP?) DLL (next command) , but it's definitely not what has been intended.