### PR TITLE
Fix config files migration

### DIFF
--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -829,17 +829,6 @@
                         <Component Id="config.README.txt" Guid="{9C3B43AF-1399-4E6A-92CA-D7BA3B6BCC3C}">
                             <File Id="config.README.txt" Name="README.txt" Source="!(bindpath.build)README-config.txt"/>
                         </Component>
-                        <!-- Move auto-start config files from configuration folder to auto-start configuration folder on update from non-auto-start aware installations. -->
-                        <Component Id="config.Where_are_my_config_files.txt" Guid="{2DFEDF05-F41E-4EB0-A90A-DC76A261E444}">
-                            <Condition><![CDATA[CONFIGDIRREG AND NOT CONFIGAUTODIRREG]]></Condition>
-                            <File Name="Where are my config files.txt" Source="!(bindpath.build)Where are my config files.txt"/>
-                            <CopyFile
-                                Id="config_auto"
-                                SourceProperty="CONFIGDIRREG"
-                                SourceName="*"
-                                DestinationProperty="CONFIGAUTODIR"
-                                Delete="yes"/>
-                        </Component>
                     </Directory>
 
                     <Directory Id="CONFIGAUTODIR" Name="config-auto">
@@ -1678,7 +1667,6 @@
                 <ComponentRef Id="bin.libopenvpn_plap.dll"/>
                 <ComponentRef Id="bin.openvpn_plap_install.reg"/>
                 <ComponentRef Id="bin.openvpn_plap_uninstall.reg"/>
-                <ComponentRef Id="config.Where_are_my_config_files.txt"/>
                 <ComponentRef Id="config_auto.README.txt"/>
                 <ComponentRef Id="reg.autostart_config_dir"/>
 


### PR DESCRIPTION
Starting from 2.5beta3

  https://github.com/OpenVPN/openvpn-build/commit/16a56571e4ee9a980496b3f19d8774d43ccfdea7

OpenVPN service uses separate directory (config-auto) for connections which require auto-start. Because of that, a migration functionality was added which moves config files from config to config-auto directory on upgrade if config-auto is missing and service is running.

Starting from 2.6rc1

  https://github.com/OpenVPN/openvpn-build/commit/1d15f8e4c5616d17fcfe744f7f9637b8f8263be7

we always install OpenVPNService, since it is problematic to add it due to lack of "Modify" action. Because of that change, when upgrading from pre 2.5beta3 to 2.6rc1 and newer, config files are always moved from config to config-auto. This happens because condition "should we start service" has been moved from Wix script to JS custom action, but the "upgrade" component in Wix script was dependent on that condition.

This commit fixes config migration functionality by moving it to JS custom action which handles OpenVPNService installation. Migration is only peformed when:

 - this is an upgrade and not clean install
 - service needs to be started
 - config directory exists
 - config-auto directory is missing in registry and on disk

As a side effect, we've lost "Where_are_my_config_files.txt" copying to config directory on migration. This can be fixed later.

Reported-by: Gert Doering <gert@greenie.muc.de>
Signed-off-by: Lev Stipakov <lev@openvpn.net>