### PR TITLE
Configs migration: add note to user

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -285,7 +285,6 @@ clean	Cleans intermediate and output files</example>
                                 BuildPath("vcredist", p.wixPlat, "vcruntime140.dll"),
                                 BuildPath(buildPath, "openvpnserv2.exe"),
                                 BuildPath(buildPath, "README-config.txt"),
-                                BuildPath(buildPath, "Where are my config files.txt"),
                                 BuildPath(buildPath, "README-config-auto.txt"),
                                 BuildPath(buildPath, "INSTALL-win32.txt"),
                                 BuildPath(openVPNDocPath, "openvpn.8.html"),
@@ -311,11 +310,6 @@ clean	Cleans intermediate and output files</example>
                     b.pushRule(new PreprocessBuildRule(
                         BuildPath(buildPath, "README-config.txt"), "utf-8", adCRLF,
                         [BuildPath("doc", "config", "README.txt.in")], "utf-8", adLF,
-                        ver,
-                        ["version.m4"]));
-                    b.pushRule(new PreprocessBuildRule(
-                        BuildPath(buildPath, "Where are my config files.txt"), "utf-8", adCRLF,
-                        [BuildPath("doc", "config", "Where are my config files.txt.in")], "utf-8", adLF,
                         ver,
                         ["version.m4"]));
                     b.pushRule(new PreprocessBuildRule(

--- a/windows-msi/doc/config/Where are my config files.txt.in
+++ b/windows-msi/doc/config/Where are my config files.txt.in
@@ -1,6 +1,0 @@
-﻿The @PRODUCT_NAME@Service has switched to a separate configuration
-directory.
-
-The update process detected that you were using @PRODUCT_NAME@Service
-to start your connections, and moved all your config files from config
-to the config-auto directory.

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -828,6 +828,7 @@
                     <Directory Id="CONFIGDIR" Name="config">
                         <Component Id="config.README.txt" Guid="{9C3B43AF-1399-4E6A-92CA-D7BA3B6BCC3C}">
                             <File Id="config.README.txt" Name="README.txt" Source="!(bindpath.build)README-config.txt"/>
+                            <RemoveFile Id="config.migrate.cleanup" Property="CONFIGDIR" Name="Where are my configs files.txt" On="uninstall"/>
                         </Component>
                     </Directory>
 

--- a/windows-msi/script/Service.js
+++ b/windows-msi/script/Service.js
@@ -70,6 +70,13 @@ function MigrateConfigs(src, dst) {
 
     try {
         fso.MoveFile(src + "\\*.ovpn", dst);
+        var ts = fso.CreateTextFile(src + "\\Where are my configs files.txt");
+        ts.WriteLine("The OpenVPNService has switched to a separate configuration directory.");
+        ts.WriteLine("");
+        ts.WriteLine("The update process detected that you were using OpenVPNService");
+        ts.WriteLine("to start your connections, and moved all your config");
+        ts.WriteLine("files from config to the config-auto directory.");
+        ts.Close();
     }
     catch (err) {
         // something wrong, but this is not super critical


### PR DESCRIPTION
When configs are migrated from config to config-auto, create a text file in config directory with explanation.

Remove this file on uninstall.

Signed-off-by: Lev Stipakov <lev@openvpn.net>