### PR TITLE
ActiveSetup: fix "Run on logon" behavior

### DIFF
--- a/windows-msi/script/ActiveSetupCA.js
+++ b/windows-msi/script/ActiveSetupCA.js
@@ -24,9 +24,19 @@
  */
 function EvaluateActiveSetup()
 {
-    var
-        productCode = Session.Property("ProductCode"),
-        version;
+    if (Session.EvaluateCondition("UPGRADINGPRODUCTCODE") == 1) {
+        // this means upgrade removes an app - no need to do anything
+        return 1;
+    }
+
+    // we use SimpleProductName (like OpenVPN) which is persistent across upgrades as productCode.
+    // otherwise on upgrade we get a different product code and "uninstall" entry for the old version
+    // could be executed after "install" entry for the new version, which will break "Run on log on"
+    //
+    // ">" prefix makes sure that our action runs last, otherwise "uninstall" action with key "{<guid>}"
+    // from previous version will run after us and undo our HKCU change
+    var productCode = ">" + Session.Property("SimpleProductName") + "_UserSetup";
+    var version;
 
     // Read the current component version from registry. Default to "0".
     try {


### PR DESCRIPTION
Starting from 2.5, "Run on logon" installer feature didn't work in cases when ProductCode of new version is "less" than ProductCode in old version in in alphanumeric comparison.

 - Install version with product code 456
 - Log off and log on so that ActiveSetup command will be added to HKCU
 - Install version with product code 123
 - Log off and log on

Here openvpn-gui won't be run, because:

 - ActiveSetup command from product 123 will be executed, which adds openvpn-gui to Windows\CurrentVersion\Run

 - ActiveSetup command from product 456 will be executed, which removes openvpn-gui from Windows\CurrentVersion\Run

To fix that, we use ">OpenVPN_UserSetup" as ActiveSetup command name, which is guaranteed to be run after all GUID name, similar to NSIS implementation https://github.com/OpenVPN/openvpn-build/commit/68d9ebf52de6be160f813297da62d43b5239ff0b

Also to not to overwrite ActiveSetup command when removing old version during upgrade, make ActiveSetup action no-op in this case.

This fixes https://github.com/OpenVPN/openvpn-build/issues/214

Signed-off-by: Lev Stipakov <lev@openvpn.net>