### PR TITLE
Install ovpn-dco from MSM

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -168,20 +168,9 @@ clean	Cleans intermediate and output files</example>
 
                         // Downloading ovpn-dco
                         b.pushRule(new DownloadBuildRule(
-                            BuildPath(p.buildPath, "ovpn-dco.zip"),
+                            BuildPath(p.buildPath, "ovpn-dco.msm"),
                             ver.define["PRODUCT_OVPN_DCO_URL_" + plat],
                             ["version.m4"]));
-
-                        // Extracting ovpn-dco
-                        b.pushRule(new ExtractBuildRule(
-                            [
-                                BuildPath(p.buildPath, "ovpn-dco", "win10", "ovpn-dco.inf"),
-                                BuildPath(p.buildPath, "ovpn-dco", "win11", "ovpn-dco.inf"),
-                            ],
-                            p.ovpnDcoPath,
-                            BuildPath(p.buildPath, "ovpn-dco.timestamp"),
-                            BuildPath(p.buildPath, "ovpn-dco.zip"),
-                            []));
 
                         // WiX compiler flags
                         var wixCompilerFlags = [
@@ -270,8 +259,7 @@ clean	Cleans intermediate and output files</example>
                                 BuildPath(p.buildPath, "license.txt"),
                                 BuildPath(p.buildPath, "tap-windows6.msm"),
                                 BuildPath(p.buildPath, "wintun.msm"),
-                                BuildPath(p.buildPath, "ovpn-dco", "win10", "ovpn-dco.inf"),
-                                BuildPath(p.buildPath, "ovpn-dco", "win11", "ovpn-dco.inf"),
+                                BuildPath(p.buildPath, "ovpn-dco.msm"),
                                 BuildPath(p.openVPNBinPath, "libcrypto-3" + p.openSSLPlat + ".dll"),
                                 BuildPath(p.openVPNBinPath, "libopenvpnmsica.dll"),
                                 BuildPath(p.openVPNBinPath, "libpkcs11-helper-1.dll"),

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -31,7 +31,7 @@
 
         <Package
             InstallScope="perMachine"
-            InstallerVersion="400"
+            InstallerVersion="500"
             Compressed="yes"
             SummaryCodepage="1252"
             ReadOnly="yes"/>
@@ -1023,42 +1023,6 @@
                         </Directory>
                     </Directory>
                 </Directory>
-
-                <Directory Id="CommonFiles" Name="Common Files">
-                    <Directory Id="OVPNDCOPARENT" Name="ovpn-dco">
-                        <Component Id="CMP_ovpn_dco.inf" Guid="4BE20469-2292-4AE2-B953-49AA0DA4165E">
-                            <RegistryValue Root="HKLM" Key="Software\$(var.PRODUCT_NAME)" Type="string" Name="ovpn-dco" Value="" KeyPath="yes"/>
-                        </Component>
-                        <Directory Id="NX20" Name="Win10">
-                            <Component Id="CMP_ovpn_dco_nx20.inf" Guid="459CA7BC-939E-438C-B830-B1390F0C05A7">
-                                <Condition>NOT NETADAPTERCX21</Condition>
-                                <File Id="ovpndco.inf" Name="ovpn-dco.inf" Source="!(bindpath.ovpndco)\win10\ovpn-dco.inf" KeyPath="yes" />
-                            </Component>
-                            <Component Id="CMP_ovpn_dco_nx20.cat" Guid="EB59AE6E-191E-4FE1-B414-005217348183">
-                                <Condition>NOT NETADAPTERCX21</Condition>
-                                <File Id="ovpndco_nx20.cat" Name="ovpn-dco.cat" Source="!(bindpath.ovpndco)\win10\ovpn-dco.cat" KeyPath="yes" />
-                            </Component>
-                            <Component Id="CMP_ovpn_dco_nx20.sys" Guid="0007BFDB-42A9-4F67-BDD9-AB3B797DEF1F">
-                                <Condition>NOT NETADAPTERCX21</Condition>
-                                <File Id="ovpndco_nx20.sys" Name="ovpn-dco.sys" Source="!(bindpath.ovpndco)\win10\ovpn-dco.sys" KeyPath="yes" />
-                            </Component>
-                        </Directory>
-                        <Directory Id="NX21" Name="Win11">
-                            <Component Id="CMP_ovpn_dco_nx21.inf" Guid="369D943E-0849-449A-9D70-AFA7AA57B0C7">
-                                <Condition>NETADAPTERCX21</Condition>
-                                <File Id="ovpndco_nx21.inf" Name="ovpn-dco.inf" Source="!(bindpath.ovpndco)\win11\ovpn-dco.inf" KeyPath="yes" />
-                            </Component>
-                            <Component Id="CMP_ovpn_dco_nx21.cat" Guid="9E873D77-8685-4B60-9066-B94D94C0EEEB">
-                                <Condition>NETADAPTERCX21</Condition>
-                                <File Id="ovpndco_nx21.cat" Name="ovpn-dco.cat" Source="!(bindpath.ovpndco)\win11\ovpn-dco.cat" KeyPath="yes" />
-                            </Component>
-                            <Component Id="CMP_ovpn_dco_nx21.sys" Guid="FB24EBB2-8521-4365-90E2-BCB5F011669E">
-                                <Condition>NETADAPTERCX21</Condition>
-                                <File Id="ovpndco_nx21.sys" Name="ovpn-dco.sys" Source="!(bindpath.ovpndco)\win11\ovpn-dco.sys" KeyPath="yes" />
-                            </Component>
-                        </Directory>
-                    </Directory>
-                </Directory>
             </Directory>
 
             <Directory Id="ProgramMenuFolder">
@@ -1423,6 +1387,9 @@
             TUN/TAP Driver Installation
         -->
         <DirectoryRef Id="PRODUCTDIR">
+            <Merge Id="OvpnDcoMergeModule" Language="0" DiskId="1" SourceFile="!(bindpath.build)$(var.PRODUCT_PLATFORM)\ovpn-dco.msm">
+                <ConfigurationData Name="NETADAPTERCX21_Property" Value="[NETADAPTERCX21]" />
+            </Merge>
             <Merge Id="TAPWindows6MergeModule" Language="0" DiskId="1" SourceFile="!(bindpath.build)$(var.PRODUCT_PLATFORM)\tap-windows6.msm"/>
             <?if $(sys.BUILDARCH)~="x86" Or $(sys.BUILDARCH)~="x64" ?>
                 <Merge Id="WintunMergeModule" Language="0" DiskId="1" SourceFile="!(bindpath.build)$(var.PRODUCT_PLATFORM)\wintun.msm"/>
@@ -1434,11 +1401,10 @@
             <ProgressText Action="$(var.PRODUCT_TAP_WIN_COMPONENT_ID)_Process">Processing TAP-Windows6 driver</ProgressText>
             <ProgressText Action="EvaluateWintun">Evaluating Wintun driver</ProgressText>
             <ProgressText Action="ProcessWintun">Processing Wintun driver</ProgressText>
-            <ProgressText Action="OvpnDcoEvaluate">Evaluating ovpn-dco driver</ProgressText>
-            <ProgressText Action="OvpnDcoProcess">Processing ovpn-dco driver</ProgressText>
+            <ProgressText Action="OvpnDco_Evaluate">Evaluating ovpn-dco driver</ProgressText>
+            <ProgressText Action="OvpnDco_Process">Processing ovpn-dco driver</ProgressText>
             <ProgressText Action="CheckAndScheduleReboot">Checking if reboot is required</ProgressText>
         </UI>
-
 
         <!--
             TUN/TAP adapters
@@ -1452,16 +1418,7 @@
         <CustomAction Id="InstallTUNTAPAdaptersRollback"   BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDeferredAction" Execute="rollback" Impersonate="no"/>
         <CustomAction Id="CheckAndScheduleReboot"          BinaryKey="libopenvpnmsica.dll" DllEntry="CheckAndScheduleReboot"/>
 
-        <!-- ovpn-dco driver -->
-        <CustomAction Id="OvpnDcoEvaluate"    BinaryKey="libopenvpnmsica.dll" DllEntry="EvaluateDriver" Execute="immediate"/>
-        <CustomAction Id="OvpnDcoProcess"     BinaryKey="libopenvpnmsica.dll" DllEntry="ProcessDriver" Execute="deferred" Impersonate="no"/>
-
-        <SetProperty Action="SetOvpnDcoWin10" Id="OVPNDCO" After="CostFinalize" Value="[OVPNDCOPARENT]Win10\" Sequence="execute"><![CDATA[NOT NETADAPTERCX21]]></SetProperty>
-        <SetProperty Action="SetOvpnDcoWin11" Id="OVPNDCO" After="CostFinalize" Value="[OVPNDCOPARENT]Win11\" Sequence="execute"><![CDATA[NETADAPTERCX21]]></SetProperty>
-
         <InstallExecuteSequence>
-            <Custom Action="OvpnDcoEvaluate"                 Before="OvpnDcoProcess"/>
-            <Custom Action="OvpnDcoProcess"                   After="InstallFiles" />
             <Custom Action="EvaluateTUNTAPAdapters"           After="ProcessComponents"/>
             <Custom Action="UninstallTUNTAPAdapters"          After="DeleteServices"/>
             <Custom Action="UninstallTUNTAPAdaptersCommit"    After="UninstallTUNTAPAdapters"/>
@@ -1557,7 +1514,7 @@
                 <Data Column="DisplayName">ovpn-dco|$(var.PRODUCT_NAME) Data Channel Offload</Data>
                 <Data Column="HardwareId" >ovpn-dco</Data>
                 <Data Column="Condition"  ><![CDATA[NOT OVPNDCOADAPTERS]]></Data>
-                <Data Column="Component_" >CMP_ovpn_dco.inf</Data>
+                <Data Column="Component_" >CMP_ovpn_dco.inf.1057B5BE_89F7_469C_A3FD_D6662CD1D229</Data>
             </Row>
         </CustomTable>
 
@@ -1726,16 +1683,8 @@
                 Id="Drivers.OvpnDco"
                 Title="Data Channel Offload"
                 Description="The new network driver which implements data channel of the OpenVPN protocol in Windows kernel."
-                Level="0"
-                ConfigurableDirectory="PRODUCTDIR"
-                AllowAdvertise="no">
-                <ComponentRef Id="CMP_ovpn_dco.inf"/>
-                <ComponentRef Id="CMP_ovpn_dco_nx20.inf"/>
-                <ComponentRef Id="CMP_ovpn_dco_nx20.cat"/>
-                <ComponentRef Id="CMP_ovpn_dco_nx20.sys"/>
-                <ComponentRef Id="CMP_ovpn_dco_nx21.inf"/>
-                <ComponentRef Id="CMP_ovpn_dco_nx21.cat"/>
-                <ComponentRef Id="CMP_ovpn_dco_nx21.sys"/>
+                Level="0">
+                <MergeRef Id="OvpnDcoMergeModule"/>
                 <ComponentRef Id="shortcut.bin.tapctl.exe.create.dco"/>
                 <Condition Level="1">WIN102004</Condition>
             </Feature>

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -1514,7 +1514,7 @@
                 <Data Column="DisplayName">ovpn-dco|$(var.PRODUCT_NAME) Data Channel Offload</Data>
                 <Data Column="HardwareId" >ovpn-dco</Data>
                 <Data Column="Condition"  ><![CDATA[NOT OVPNDCOADAPTERS]]></Data>
-                <Data Column="Component_" >CMP_ovpn_dco.inf.1057B5BE_89F7_469C_A3FD_D6662CD1D229</Data>
+                <Data Column="Component_" >shortcut.bin.tapctl.exe.create.dco</Data>
             </Row>
         </CustomTable>
 

--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -16,9 +16,9 @@ dnl This is only to make build script happy - the file is only downloaded but no
 define([PRODUCT_WINTUN_URL_arm64],     [https://build.openvpn.net/downloads/releases/wintun-amd64-0.8.1.msm])
 
 dnl ovpn-dco binaries
-define([PRODUCT_OVPN_DCO_URL_x86],     [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.8.3/ovpn-dco-win-0.8.3-x86.zip])
-define([PRODUCT_OVPN_DCO_URL_amd64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.8.3/ovpn-dco-win-0.8.3-amd64.zip])
-define([PRODUCT_OVPN_DCO_URL_arm64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.8.3/ovpn-dco-win-0.8.3-arm64.zip])
+define([PRODUCT_OVPN_DCO_URL_x86],     [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.8.3/ovpn-dco-x86.msm])
+define([PRODUCT_OVPN_DCO_URL_amd64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.8.3/ovpn-dco-amd64.msm])
+define([PRODUCT_OVPN_DCO_URL_arm64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.8.3/ovpn-dco-arm64.msm])
 
 dnl OpenVPNServ2.exe binary
 define([OPENVPNSERV2_URL], [http://build.openvpn.net/downloads/releases/openvpnserv2-1.4.0.1.exe])


### PR DESCRIPTION
ovpn-dco installation logic has been moved into MSM so that it can be reused by Connect and both openvpn-gui and Connect could co-exist and use the same driver.