### PR TITLE
debian-sbuild: remove --enable-iproute2 for Ubuntu focal (20.04LTS)

### DIFF
--- a/debian-sbuild/packaging/focal/debian/NEWS
+++ b/debian-sbuild/packaging/focal/debian/NEWS
@@ -1,3 +1,15 @@
+openvpn (2.6.2-focal0) unstable; urgency=medium
+
+  * In the community-built packages for 2.6.2 --enable-iproute2 was
+    removed from build configuration. This makes the package compatible
+    with using the DCO kernel module. It should make no difference
+    for most setups. If you encounter any regressions you might need
+    to go back to 2.6.1 for now. It is recommended not to depend on
+    the behavior of --enable-iproute2 in the long term since it is
+    deprecated.
+
+ -- Frank Lichtenheld <frank.lichtenheld@openvpn.net>  Thu, 23 Mar 2023 10:00:19 +0100
+
 openvpn (2.4.0-4) unstable; urgency=medium
 
     If you're upgrading a previous OpenVPN installation, you should check your

--- a/debian-sbuild/packaging/focal/debian/rules
+++ b/debian-sbuild/packaging/focal/debian/rules
@@ -6,7 +6,7 @@ ENV_VARS	:= IFCONFIG=/sbin/ifconfig ROUTE=/lib/freebsd/route
 EXTRA_ARGS	:=
 else
 ENV_VARS	:= SYSTEMD_ASK_PASSWORD=/bin/systemd-ask-password IFCONFIG=/sbin/ifconfig ROUTE=/sbin/route IPROUTE=/sbin/ip SYSTEMD_UNIT_DIR=/lib/systemd/system TMPFILES_DIR=/usr/lib/tmpfiles.d
-EXTRA_ARGS	:= --enable-systemd --enable-iproute2
+EXTRA_ARGS	:= --enable-systemd
 endif
 
 #export DH_VERBOSE=1


### PR DESCRIPTION
Establishing DCO compatiblity is more important than trying to be compatible with setups that depend on --enable-iproute2.

Related to OpenVPN/openvpn-build#333