### PR TITLE
msi: configure OpenVPN Service also on reinstall

### DIFF
--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -100,7 +100,7 @@
         <InstallExecuteSequence>
             <Custom Action="FindSystemInfo" After="FindRelatedProducts"/>
             <Custom Action="CheckOpenVPNServiceStatus" After="ProcessComponents"/>
-            <Custom Action="ConfigureOpenVPNService" After="StartServices">NOT Installed</Custom>
+            <Custom Action="ConfigureOpenVPNService" After="StartServices">NOT REMOVE</Custom>
             <Custom Action="GetInstallDir" After="FindRelatedProducts"/>
             <Custom Action="UpdatePlapReg" After="InstallFiles"/>
         </InstallExecuteSequence>


### PR DESCRIPTION
We configure openvpn service (set startup mode and run, if needed) only on installation or upgrade. This is achieved by running configuration custom action with "NOT Installed" condition.

However the product may be reinstalled (even though we disable it in UI), for example when pushed via AD Group Policy or with command line

    msiexec /fomusv "OpenVPN-2.6.2-I001-amd64.msi" /L*V reinstall.log

In this case OpenVPN service status is set to "disabled", since our configuration custom action won't be run.

Fix by changing action condition to NOT REMOVE, which covers both install/upgrade and reinstall cases.

Fixes https://github.com/OpenVPN/openvpn-build/issues/348

Change-Id: I92974dea4749c415e25ab0f804050e3e6d309ffc