### PR TITLE
msi/easyrsa: fix openssl path search on non-English Windows

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -143,7 +143,7 @@ clean	Cleans intermediate and output files</example>
                         [
                             "@echo OFF",
                             "rem Automatically set PATH to openssl.exe",
-                            "FOR /F \"tokens=2*\" %%a IN ('REG QUERY \"HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenVPN\" /ve') DO set \"PATH=%PATH%;%%b\\bin\"",
+                            "FOR /F \"tokens=2*\" %%a IN ('REG QUERY \"HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenVPN\" /v bin_dir') DO set \"PATH=%PATH%;%%b\"",
                             "bin\\sh.exe bin\\easyrsa-shell-init.sh"
                         ],
                         ["version.m4"]));

--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -1188,6 +1188,14 @@
                     Type="string"
                     Value="[PRODUCTDIR]"/>
             </Component>
+            <Component Id="reg.bin_dir" Guid="{E027FA2F-18AD-466E-9943-15CBE6C7C45B}">
+                <RegistryValue
+                    Root="HKLM"
+                    Key="Software\$(var.PRODUCT_NAME)"
+                    Name="bin_dir"
+                    Type="string"
+                    Value="[BINDIR]"/>
+            </Component>
             <Component Id="reg.config_dir" Guid="{FA8F296E-3808-4861-AEC1-A14062D060AF}">
                 <RegistryValue
                     Root="HKLM"
@@ -1570,6 +1578,7 @@
             <ComponentRef Id="log.README.txt"/>
             <ComponentRef Id="res.ovpn.ico"/>
             <ComponentRef Id="reg.path"/>
+            <ComponentRef Id="reg.bin_dir"/>
             <ComponentRef Id="reg.config_dir"/>
             <ComponentRef Id="reg.config_ext"/>
             <ComponentRef Id="reg.exe_path"/>


### PR DESCRIPTION
The current implementation doesn't work well when the first column of "reg query" output contains two words (example from UA/RU):

  C:\Users\diach>REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE" /ve

  HKEY_LOCAL_MACHINE\SOFTWARE
      (po umolchaniyu)    REG_SZ

Workaround this by adding a registy key "bin_dir", in which case we don't care about two-worded values anymore.

  PS C:\Users\lev> REG QUERY HKEY_LOCAL_MACHINE\SOFTWARE\OpenVPN /v bin_dir

  HKEY_LOCAL_MACHINE\SOFTWARE\OpenVPN
      bin_dir    REG_SZ    C:\Program Files\OpenVPN\bin\

Fixes https://github.com/OpenVPN/openvpn-build/issues/352

Change-Id: I00114438a61a498535d5d7e143df8a115d655a97