### PR TITLE
windows-msi: don't depend on core.autocrlf=false

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -207,15 +207,15 @@ clean	Cleans intermediate and output files</example>
                             [
                                 BuildPath(depsPath, "openvpn", "COPYING"),
                                 BuildPath(depsPath, "openvpn", "COPYRIGHT.GPL")
-                            ], "utf-8", adLF,
+                            ], "utf-8", adCRLF,
                             []));
                         b.pushRule(new ConvertTextBuildRule(
                             BuildPath(p.buildPath, "client.ovpn"), "utf-8", adCRLF,
-                            [BuildPath(depsPath, "openvpn", "sample", "sample-config-files", "client.conf")], "utf-8", adLF,
+                            [BuildPath(depsPath, "openvpn", "sample", "sample-config-files", "client.conf")], "utf-8", adCRLF,
                             []));
                         b.pushRule(new ConvertTextBuildRule(
                             BuildPath(p.buildPath, "server.ovpn"), "utf-8", adCRLF,
-                            [BuildPath(depsPath, "openvpn", "sample", "sample-config-files", "server.conf")], "utf-8", adLF,
+                            [BuildPath(depsPath, "openvpn", "sample", "sample-config-files", "server.conf")], "utf-8", adCRLF,
                             []));
                         // WiX linker flags
                         var wixLinkerFlags = [


### PR DESCRIPTION
The build script assumed that the sample files in
openvpn were checked out with LF line-endings. Since these files have no eol enforced by .gitattributes in openvpn, this depends on core.autocrlf=false, which is not the default on Windows.

So assume that these files will be checked out with CRLF line endings on Windows. The alternative would be to enforce LF line-endings via openvpn's
.gitattributes.

Fixes #358