### PR TITLE
GHA: use vcpkg submodule without updating to latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,10 +29,12 @@ jobs:
         with:
           path: openvpn-build
 
+      # Don't use latest vcpkg: https://github.com/microsoft/vcpkg/issues/31170
       - name: Checkout submodules (by branch)
         working-directory: openvpn-build
         run: |
           git submodule update --init --remote --recursive
+          git submodule update src/vcpkg
 
       - name: vcpkg pre-download
         working-directory: openvpn-build/src/vcpkg


### PR DESCRIPTION
Latest vcpkg openssl port broken right now.
See https://github.com/microsoft/vcpkg/pull/31171