### PR TITLE
Bump Easy-RSA to version 3.1.5

### DIFF
--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -29,8 +29,8 @@ dnl The OpenSSL binaries, which come with Easy-RSA, are not used by Openvpn-buil
 dnl The only binaries which Openvpn-build uses from Easy-RSA, are the *nix style
 dnl (32bit only) binaries for Windows, from easy-rsa/distro/windows/bin.
 dnl Further details: easy-rsa/distro/windows/Licensing/mksh-Win32.txt
-define([EASYRSA_VERSION], [3.1.2])
-define([EASYRSA_URL],     [https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.2/EasyRSA-3.1.2-win64.zip])
+define([EASYRSA_VERSION], [3.1.5])
+define([EASYRSA_URL],     [https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.5/EasyRSA-3.1.5-win64.zip])
 
 dnl ============================================================
 dnl MSI Provisioning


### PR DESCRIPTION
Easy-RSA version 3.1.5 introduces a new method, called 'RAW', to generate a CA with a password, without writing that password to the disk.  This is done by handing over all password inputs to the SSL binary.  Easy-RSA does not interfere with the password.

Omit Easy-RSA version 3.1.4:
Easy-RSA version 3.1.4 use of file-descritors proved to be of no value. This is because use of file-descriptors results in temp files being written to disk.

Omit Easy-RSA version 3.1.3:
Easy-RSA version 3.1.3 is unable to build a CA using Windows, due to use of file-descriptors, which OpenSSL built for Windows does not support.

Easy-RSA ChangeLog has further details.