### PR TITLE
GHA: make all action versions explicit (release/2.6)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout openvpn-build
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Checkout submodules (by branch)
         run: |
@@ -38,13 +38,13 @@ jobs:
           Invoke-WebRequest -Uri "https://build.openvpn.net/downloads/temp/strawberry-perl-5.32.1.1-32bit.zip" -OutFile ".\downloads\strawberry-perl-5.32.1.1-32bit.zip"
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.26.4
 
       - name: Install rst2html
         run: python -m pip install --upgrade pip rst2html
 
       - name: Setup MSVC prompt
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1.12.1
 
       - name: Install Wix 3.14
         run: |
@@ -80,7 +80,7 @@ jobs:
           echo "DATETIME=${dt}" >> $Env:GITHUB_ENV
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: openvpn-master-${{ env.DATETIME }}-${{ env.OPENVPN_COMMIT }}-${{ matrix.arch }}
           path: ${{ github.workspace }}\windows-msi\image\*-${{ matrix.arch }}.msi
@@ -96,27 +96,27 @@ jobs:
 
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2.2.0
         with:
           role-to-assume: arn:aws:iam::217307881341:role/GitHubActions
           role-session-name: githubactions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Clone openvpn-windows-test repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: openvpn/openvpn-windows-test
           ref: master
           path: openvpn-windows-test
 
       - name: Install SSH key for tclient host
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.SSH_KEY_FOR_TCLIENT_HOST }}
           known_hosts: unnecessary
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           path: msi
 
@@ -129,7 +129,7 @@ jobs:
           .\Start-AWSTest.ps1 -SSH_KEY ~/.ssh/id_rsa -MSI_PATH $(Get-ChildItem ../msi/*-amd64/*.msi | select -ExpandProperty FullName)
 
       - name: Archive openvpn logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         if: ${{ always() }}
         with:
           name: t_client_openvpn_logs
@@ -146,7 +146,7 @@ jobs:
         run: sudo apt install knockd
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           path: msi
 
@@ -160,7 +160,7 @@ jobs:
         run: knock -d 500 ${{ secrets.MSI_UPLOAD_REMOTE_HOST }} ${{ secrets.MSI_UPLOAD_REMOTE_KNOCK_SEQUENCE }} ; sleep 1
 
       - name: Copy MSI to remote
-        uses: garygrossgarten/github-action-scp@release
+        uses: garygrossgarten/github-action-scp@v0.8.0
         with:
           local: msi
           remote: ${{ secrets.MSI_UPLOAD_REMOTE_PATH }}
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Checkout openvpn-build
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Checkout submodules (by branch)
         run: |
@@ -211,7 +211,7 @@ jobs:
 
       - name: Restore cached chroots
         id: chroots-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v3.3.1
         with:
           path: |
             debian-sbuild/chroots
@@ -242,7 +242,7 @@ jobs:
           sg sbuild ./scripts/build-all.sh
 
       - name: Archive packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: openvpn-debian
           path: |
@@ -250,7 +250,7 @@ jobs:
 
       - name: Save chroots
         id: chroots-save
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v3.3.1
         with:
           path: |
             debian-sbuild/chroots


### PR DESCRIPTION
I want to handle updating them automatically, but for that we need to pin them to exact versions, first.

Related to #380 (Renovate support).