### PR TITLE
windows-msi: For files from GitHub releases factor out version number

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -65,6 +65,7 @@ clean	Cleans intermediate and output files</example>
                     "openSSLBinPath": BuildPath(depsPath, "openvpn", "src", "openvpn", "vcpkg_installed", "x86-windows-ovpn", "x86-windows-ovpn", "bin"),
                     "programFilesPath": "ProgramFilesFolder",
                     "openSSLPlat": "",
+                    "tapWinPlat": "i386",
                     "wixPlat": "x86",
                     "wixLinkDepenencies": [],
                     "ovpnDcoPath": BuildPath(buildPath, "x86", "ovpn-dco")
@@ -79,6 +80,7 @@ clean	Cleans intermediate and output files</example>
                     "openSSLBinPath": BuildPath(depsPath, "openvpn", "src", "openvpn", "vcpkg_installed", "x64-windows-ovpn", "x64-windows-ovpn", "bin"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-x64",
+                    "tapWinPlat": "amd64",
                     "wixPlat": "x64",
                     "wixLinkDepenencies": [],
                     "ovpnDcoPath": BuildPath(buildPath, "amd64", "ovpn-dco")
@@ -93,6 +95,7 @@ clean	Cleans intermediate and output files</example>
                     "openSSLBinPath": BuildPath(depsPath, "openvpn", "src", "openvpn", "vcpkg_installed", "arm64-windows-ovpn", "arm64-windows-ovpn", "bin"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-arm64",
+                    "tapWinPlat": "arm64",
                     "wixPlat": "arm64",
                     "wixLinkDepenencies": [],
                     "ovpnDcoPath": BuildPath(buildPath, "arm64", "ovpn-dco")
@@ -128,7 +131,7 @@ clean	Cleans intermediate and output files</example>
                     // Downloading and extracting Easy RSA
                     b.pushRule(new DownloadBuildRule(
                         BuildPath(sourcePath, "easyrsa-" + ver.define.EASYRSA_VERSION + ".zip"),
-                        ver.define.EASYRSA_URL,
+                        "https://github.com/OpenVPN/easy-rsa/releases/download/v" + ver.define.EASYRSA_VERSION + "/EasyRSA-" + ver.define.EASYRSA_VERSION + "-win64.zip",
                         ["version.m4"]));
                     b.pushRule(new ExtractBuildRule(
                         [
@@ -157,7 +160,7 @@ clean	Cleans intermediate and output files</example>
                         // Downloading TAP-Windows6
                         b.pushRule(new DownloadBuildRule(
                             BuildPath(p.buildPath, "tap-windows6.msm"),
-                            ver.define["PRODUCT_TAP_WIN_URL_" + plat],
+                            "https://github.com/OpenVPN/tap-windows6/releases/download/" + ver.define.PRODUCT_TAP_WIN_VERSION + "/tap-windows-" + ver.define.PRODUCT_TAP_WIN_VERSION + "-" + ver.define.PRODUCT_TAP_WIN_INSTALLER_VERSION + "-" + p.tapWinPlat + ".msm",
                             ["version.m4"]));
 
                         // Downloading Wintun
@@ -169,7 +172,7 @@ clean	Cleans intermediate and output files</example>
                         // Downloading ovpn-dco
                         b.pushRule(new DownloadBuildRule(
                             BuildPath(p.buildPath, "ovpn-dco.msm"),
-                            ver.define["PRODUCT_OVPN_DCO_URL_" + plat],
+                            "https://github.com/OpenVPN/ovpn-dco-win/releases/download/" + ver.define.PRODUCT_OVPN_DCO_VERSION + "/ovpn-dco-" + plat + ".msm",
                             ["version.m4"]));
 
                         // WiX compiler flags

--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -3,11 +3,12 @@ dnl Downloadables
 dnl ============================================================
 
 dnl TAP-Windows binaries
-define([PRODUCT_TAP_WIN_URL_x86],      [https://github.com/OpenVPN/tap-windows6/releases/download/9.26.0/tap-windows-9.26.0-I0-i386.msm])
-define([PRODUCT_TAP_WIN_URL_amd64],    [https://github.com/OpenVPN/tap-windows6/releases/download/9.26.0/tap-windows-9.26.0-I0-amd64.msm])
-define([PRODUCT_TAP_WIN_URL_arm64],    [https://github.com/OpenVPN/tap-windows6/releases/download/9.26.0/tap-windows-9.26.0-I0-arm64.msm])
-define([PRODUCT_TAP_WIN_COMPONENT_ID], [tap0901])
-define([PRODUCT_TAP_WIN_NAME],         [TAP-Windows])
+dnl renovate: datasource=github-releases depName=OpenVPN/tap-windows6
+define([PRODUCT_TAP_WIN_VERSION],           [9.26.0])
+dnl Note: Not handled by renovate
+define([PRODUCT_TAP_WIN_INSTALLER_VERSION], [I0])
+define([PRODUCT_TAP_WIN_COMPONENT_ID],      [tap0901])
+define([PRODUCT_TAP_WIN_NAME],              [TAP-Windows])
 
 dnl Wintun binaries
 define([PRODUCT_WINTUN_URL_x86],       [https://build.openvpn.net/downloads/releases/wintun-x86-0.8.1.msm])
@@ -16,9 +17,8 @@ dnl This is only to make build script happy - the file is only downloaded but no
 define([PRODUCT_WINTUN_URL_arm64],     [https://build.openvpn.net/downloads/releases/wintun-amd64-0.8.1.msm])
 
 dnl ovpn-dco binaries
-define([PRODUCT_OVPN_DCO_URL_x86],     [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.9.3/ovpn-dco-x86.msm])
-define([PRODUCT_OVPN_DCO_URL_amd64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.9.3/ovpn-dco-amd64.msm])
-define([PRODUCT_OVPN_DCO_URL_arm64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.9.3/ovpn-dco-arm64.msm])
+dnl renovate: datasource=github-releases depName=OpenVPN/ovpn-dco-win
+define([PRODUCT_OVPN_DCO_VERSION],     [0.9.3])
 
 dnl OpenVPNServ2.exe binary
 define([OPENVPNSERV2_URL], [http://build.openvpn.net/downloads/releases/openvpnserv2-1.4.0.1.exe])
@@ -29,8 +29,8 @@ dnl The OpenSSL binaries, which come with Easy-RSA, are not used by Openvpn-buil
 dnl The only binaries which Openvpn-build uses from Easy-RSA, are the *nix style
 dnl (32bit only) binaries for Windows, from easy-rsa/distro/windows/bin.
 dnl Further details: easy-rsa/distro/windows/Licensing/mksh-Win32.txt
+dnl renovate: datasource=github-releases depName=OpenVPN/easy-rsa
 define([EASYRSA_VERSION], [3.1.5])
-define([EASYRSA_URL],     [https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.5/EasyRSA-3.1.5-win64.zip])
 
 dnl ============================================================
 dnl MSI Provisioning


### PR DESCRIPTION
So that we can in the next step than manage updates with renovate. Commented annotations are modelled after regex manager examples from renovate documentation.

Related to #380 (Renovate Support).