### PR TITLE
Renovate Support

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [ "config:best-practices" ],
+    "baseBranches": [ "master", "release/2.6" ],
+    "dependencyDashboardTitle": "Dependency Dashboard self-hosted",
+    "gitAuthor": "OpenVPN Renovate <pkg@openvpn.net>",
+    "onboarding": true,
+    "onboardingBranch": "renovate/configure",
+    "platform": "github",
+    "repositories": [],
+    "git-submodules": {
+        "enabled": true
+    }
+}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout openvpn-build
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Checkout submodules (by branch)
         run: |
@@ -38,13 +38,13 @@ jobs:
           vcpkgJsonGlob: '**/src/openvpn/contrib/vcpkg-manifests/windows/vcpkg.json'
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.26.4
 
       - name: Install rst2html
         run: python -m pip install --upgrade pip docutils
 
       - name: Setup MSVC prompt
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1.12.1
 
       - name: Install Wix 3.14
         run: |
@@ -80,7 +80,7 @@ jobs:
           echo "DATETIME=${dt}" >> $Env:GITHUB_ENV
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: openvpn-master-${{ env.DATETIME }}-${{ env.OPENVPN_COMMIT }}-${{ matrix.arch }}
           path: ${{ github.workspace }}\windows-msi\image\*-${{ matrix.arch }}.msi
@@ -96,27 +96,27 @@ jobs:
 
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2.2.0
         with:
           role-to-assume: arn:aws:iam::217307881341:role/GitHubActions
           role-session-name: githubactions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Clone openvpn-windows-test repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: openvpn/openvpn-windows-test
           ref: master
           path: openvpn-windows-test
 
       - name: Install SSH key for tclient host
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.SSH_KEY_FOR_TCLIENT_HOST }}
           known_hosts: unnecessary
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           path: msi
 
@@ -129,7 +129,7 @@ jobs:
           .\Start-AWSTest.ps1 -SSH_KEY ~/.ssh/id_rsa -MSI_PATH $(Get-ChildItem ../msi/*-amd64/*.msi | select -ExpandProperty FullName)
 
       - name: Archive openvpn logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         if: ${{ always() }}
         with:
           name: t_client_openvpn_logs
@@ -146,7 +146,7 @@ jobs:
         run: sudo apt install knockd
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           path: msi
 
@@ -160,7 +160,7 @@ jobs:
         run: knock -d 500 ${{ secrets.MSI_UPLOAD_REMOTE_HOST }} ${{ secrets.MSI_UPLOAD_REMOTE_KNOCK_SEQUENCE }} ; sleep 1
 
       - name: Copy MSI to remote
-        uses: garygrossgarten/github-action-scp@release
+        uses: garygrossgarten/github-action-scp@v0.8.0
         with:
           local: msi
           remote: ${{ secrets.MSI_UPLOAD_REMOTE_PATH }}
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Checkout openvpn-build
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Checkout submodules (by branch)
         run: |
@@ -211,7 +211,7 @@ jobs:
 
       - name: Restore cached chroots
         id: chroots-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v3.3.1
         with:
           path: |
             debian-sbuild/chroots
@@ -242,7 +242,7 @@ jobs:
           sg sbuild ./scripts/build-all.sh
 
       - name: Archive packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: openvpn-debian
           path: |
@@ -250,7 +250,7 @@ jobs:
 
       - name: Save chroots
         id: chroots-save
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v3.3.1
         with:
           path: |
             debian-sbuild/chroots

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
           git submodule update --init --remote --recursive
 
       - name: Restore from cache and install vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@v11.1
         with:
           vcpkgDirectory: '${{ github.workspace }}/src/vcpkg'
           vcpkgJsonGlob: '**/src/openvpn/contrib/vcpkg-manifests/windows/vcpkg.json'

--- a/.github/workflows/depgraph.yaml
+++ b/.github/workflows/depgraph.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.3
       with:
         submodules: 'recursive'
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.3
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,19 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0/30 * * * *'
+  workflow_dispatch:
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v38.1.7
+        with:
+          configurationFile: .github/renovate-config.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: "[\"${{ github.repository }}\"]"

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,18 @@
         {
             "matchDepNames": ["src/vcpkg"],
             "extends": ["schedule:weekly"]
+        },
+        {
+            "matchPackageNames": ["OpenVPN/easy-rsa"],
+            "extractVersion": "^v(?<version>.*)$"
+        }
+    ],
+    "regexManagers": [
+        {
+            "fileMatch": ["windows-msi/version.m4$"],
+            "matchStrings": [
+                "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sdefine\\(\\[.*?\\],\\s*\\[(?<currentValue>.*?)\\]\\)\\s"
+            ]
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "matchDepNames": ["src/vcpkg"],
+            "extends": ["schedule:weekly"]
+        }
+    ]
+}

--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -68,6 +68,7 @@ clean	Cleans intermediate and output files</example>
                     "openSSLBinPath": BuildPath(depsPath, "openvpn", "out", "build", "win-x86-release", "vcpkg_installed", "x86-windows-ovpn", "bin"),
                     "programFilesPath": "ProgramFilesFolder",
                     "openSSLPlat": "",
+                    "tapWinPlat": "i386",
                     "wixPlat": "x86",
                     "wixLinkDepenencies": [],
                     "ovpnDcoPath": BuildPath(buildPath, "x86", "ovpn-dco")
@@ -86,6 +87,7 @@ clean	Cleans intermediate and output files</example>
                     "openSSLBinPath": BuildPath(depsPath, "openvpn", "out", "build", "win-amd64-release", "vcpkg_installed", "x64-windows-ovpn", "bin"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-x64",
+                    "tapWinPlat": "amd64",
                     "wixPlat": "x64",
                     "wixLinkDepenencies": [],
                     "ovpnDcoPath": BuildPath(buildPath, "amd64", "ovpn-dco")
@@ -104,6 +106,7 @@ clean	Cleans intermediate and output files</example>
                     "openSSLBinPath": BuildPath(depsPath, "openvpn", "out", "build", "win-arm64-release", "vcpkg_installed", "arm64-windows-ovpn", "bin"),
                     "programFilesPath": "ProgramFiles64Folder",
                     "openSSLPlat": "-arm64",
+                    "tapWinPlat": "arm64",
                     "wixPlat": "arm64",
                     "wixLinkDepenencies": [],
                     "ovpnDcoPath": BuildPath(buildPath, "arm64", "ovpn-dco")
@@ -139,7 +142,7 @@ clean	Cleans intermediate and output files</example>
                     // Downloading and extracting Easy RSA
                     b.pushRule(new DownloadBuildRule(
                         BuildPath(sourcePath, "easyrsa-" + ver.define.EASYRSA_VERSION + ".zip"),
-                        ver.define.EASYRSA_URL,
+                        "https://github.com/OpenVPN/easy-rsa/releases/download/v" + ver.define.EASYRSA_VERSION + "/EasyRSA-" + ver.define.EASYRSA_VERSION + "-win64.zip",
                         ["version.m4"]));
                     b.pushRule(new ExtractBuildRule(
                         [
@@ -168,7 +171,7 @@ clean	Cleans intermediate and output files</example>
                         // Downloading TAP-Windows6
                         b.pushRule(new DownloadBuildRule(
                             BuildPath(p.buildPath, "tap-windows6.msm"),
-                            ver.define["PRODUCT_TAP_WIN_URL_" + plat],
+                            "https://github.com/OpenVPN/tap-windows6/releases/download/" + ver.define.PRODUCT_TAP_WIN_VERSION + "/tap-windows-" + ver.define.PRODUCT_TAP_WIN_VERSION + "-" + ver.define.PRODUCT_TAP_WIN_INSTALLER_VERSION + "-" + p.tapWinPlat + ".msm",
                             ["version.m4"]));
 
                         // Downloading Wintun
@@ -180,7 +183,7 @@ clean	Cleans intermediate and output files</example>
                         // Downloading ovpn-dco
                         b.pushRule(new DownloadBuildRule(
                             BuildPath(p.buildPath, "ovpn-dco.msm"),
-                            ver.define["PRODUCT_OVPN_DCO_URL_" + plat],
+                            "https://github.com/OpenVPN/ovpn-dco-win/releases/download/" + ver.define.PRODUCT_OVPN_DCO_VERSION + "/ovpn-dco-" + plat + ".msm",
                             ["version.m4"]));
 
                         // WiX compiler flags

--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -3,11 +3,12 @@ dnl Downloadables
 dnl ============================================================
 
 dnl TAP-Windows binaries
-define([PRODUCT_TAP_WIN_URL_x86],      [https://github.com/OpenVPN/tap-windows6/releases/download/9.26.0/tap-windows-9.26.0-I0-i386.msm])
-define([PRODUCT_TAP_WIN_URL_amd64],    [https://github.com/OpenVPN/tap-windows6/releases/download/9.26.0/tap-windows-9.26.0-I0-amd64.msm])
-define([PRODUCT_TAP_WIN_URL_arm64],    [https://github.com/OpenVPN/tap-windows6/releases/download/9.26.0/tap-windows-9.26.0-I0-arm64.msm])
-define([PRODUCT_TAP_WIN_COMPONENT_ID], [tap0901])
-define([PRODUCT_TAP_WIN_NAME],         [TAP-Windows])
+dnl renovate: datasource=github-releases depName=OpenVPN/tap-windows6
+define([PRODUCT_TAP_WIN_VERSION],           [9.26.0])
+dnl Note: Not handled by renovate
+define([PRODUCT_TAP_WIN_INSTALLER_VERSION], [I0])
+define([PRODUCT_TAP_WIN_COMPONENT_ID],      [tap0901])
+define([PRODUCT_TAP_WIN_NAME],              [TAP-Windows])
 
 dnl Wintun binaries
 define([PRODUCT_WINTUN_URL_x86],       [https://build.openvpn.net/downloads/releases/wintun-x86-0.8.1.msm])
@@ -16,9 +17,8 @@ dnl This is only to make build script happy - the file is only downloaded but no
 define([PRODUCT_WINTUN_URL_arm64],     [https://build.openvpn.net/downloads/releases/wintun-amd64-0.8.1.msm])
 
 dnl ovpn-dco binaries
-define([PRODUCT_OVPN_DCO_URL_x86],     [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.9.3/ovpn-dco-x86.msm])
-define([PRODUCT_OVPN_DCO_URL_amd64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.9.3/ovpn-dco-amd64.msm])
-define([PRODUCT_OVPN_DCO_URL_arm64],   [https://github.com/OpenVPN/ovpn-dco-win/releases/download/0.9.3/ovpn-dco-arm64.msm])
+dnl renovate: datasource=github-releases depName=OpenVPN/ovpn-dco-win
+define([PRODUCT_OVPN_DCO_VERSION],     [0.9.3])
 
 dnl OpenVPNServ2.exe binary
 define([OPENVPNSERV2_URL], [http://build.openvpn.net/downloads/releases/openvpnserv2-1.4.0.1.exe])
@@ -29,8 +29,8 @@ dnl The OpenSSL binaries, which come with Easy-RSA, are not used by Openvpn-buil
 dnl The only binaries which Openvpn-build uses from Easy-RSA, are the *nix style
 dnl (32bit only) binaries for Windows, from easy-rsa/distro/windows/bin.
 dnl Further details: easy-rsa/distro/windows/Licensing/mksh-Win32.txt
+dnl renovate: datasource=github-releases depName=OpenVPN/easy-rsa
 define([EASYRSA_VERSION], [3.1.5])
-define([EASYRSA_URL],     [https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.5/EasyRSA-3.1.5-win64.zip])
 
 dnl ============================================================
 dnl MSI Provisioning


### PR DESCRIPTION
Add basic support to track dependencies:

* On git submodules
* On GitHub actions
* On GitHub releases in version.m4

All functionality has been tested in flichtenheld/openvpn-build.

This PR also merged the required changes from release/2.6 to master.

Closes: #380 