### PR TITLE
Easy-RSA: Allow 'EasyRSA-Start.bat' to pass command line options

### DIFF
--- a/windows-msi/build.wsf
+++ b/windows-msi/build.wsf
@@ -158,7 +158,7 @@ clean	Cleans intermediate and output files</example>
                             "@echo OFF",
                             "rem Automatically set PATH to openssl.exe",
                             "FOR /F \"tokens=2*\" %%a IN ('REG QUERY \"HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenVPN\" /v bin_dir') DO set \"PATH=%PATH%;%%b\"",
-                            "bin\\sh.exe bin\\easyrsa-shell-init.sh"
+                            "bin\\sh.exe bin\\easyrsa-shell-init.sh %*"
                         ],
                         ["version.m4"]));
 


### PR DESCRIPTION
The addition of `'%*'` allows EasyRSA-Start.bat to pass all command line options on to EasyRSA initialisation: 'sh.exe easyrsa-shell-init.sh %*'.

There is no specific use case here, simply that the batch file will pass options as expected.

Further patches for a new "Windows Start Menu item" can take advantage of this by passing along a new "non-admin" option.