### PR TITLE
Bump ovpn-dco-win to 1.1.1

### DIFF
--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -18,7 +18,7 @@ define([PRODUCT_WINTUN_URL_arm64],     [https://build.openvpn.net/downloads/rele
 
 dnl ovpn-dco binaries
 dnl renovate: datasource=github-releases depName=OpenVPN/ovpn-dco-win
-define([PRODUCT_OVPN_DCO_VERSION],     [1.0.1])
+define([PRODUCT_OVPN_DCO_VERSION],     [1.1.1])
 
 dnl OpenVPNServ2.exe binary
 define([OPENVPNSERV2_URL], [http://build.openvpn.net/downloads/releases/openvpnserv2-1.4.0.1.exe])


### PR DESCRIPTION
Renovate picked the deleted tag (1.1.0) so had to make PR manually.