### PR TITLE
GHA: git: configure GHA user name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -195,6 +195,9 @@ jobs:
         run: |
           ln -s vars.example vars
           mkdir ../output
+          # we need to have ability to git tag the versions
+          # we do not push that tags
+          git config --global user.name "gha_user"
           ./version-and-tags.sh
           ./create-release-files.sh
 


### PR DESCRIPTION
We need to have ability to tag the builds.
Updated release flow tries to tag openvpn-gui
if this tag does not exist.
Before that was done manually.