### PR TITLE
GHA: git: configure user name and email

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -195,6 +195,10 @@ jobs:
         run: |
           ln -s vars.example vars
           mkdir ../output
+          # we need to have ability to git tag the versions
+          # we do not push those tags
+          git config --global user.name "gha_user"
+          git config --global user.email "gha@openvpn.invalid"
           ./version-and-tags.sh
           ./create-release-files.sh
 


### PR DESCRIPTION
We need to have ability to tag the builds.
New release flow tries to tag openvpn-gui
if this tag does not exist.
Before that was done manually.