### PR TITLE
msi: use SIDs instead of built-in group names

### DIFF
--- a/windows-msi/script/ACL.js
+++ b/windows-msi/script/ACL.js
@@ -171,7 +171,8 @@ function SetACL() {
     targetDir = TrimTrailingSlash(targetDir);
 
     try {
-        RunIcacls('\"' + targetDir + '\" /inheritance:r /grant "Administrators:(OI)(CI)F" /grant "System:(OI)(CI)F" /grant "Users:(OI)(CI)RX"');
+        // Administrators, SYSTEM, Users
+        RunIcacls('\"' + targetDir + '\" /inheritance:r /grant "*S-1-5-32-544:(OI)(CI)F" /grant "*S-1-5-18:(OI)(CI)F" /grant "*S-1-5-32-545:(OI)(CI)RX"');
     } catch (e) {
         Session.Property("CUSTOMACTIONERROR") = e.message;
         return 1603; // Indicates a fatal error during installation.


### PR DESCRIPTION
Group names are localized in some localizations, so we have to use SIDs.

Fixes https://github.com/OpenVPN/openvpn-build/issues/671.