### PR TITLE
[PoC] Switch Windows Signing to GoogleCloud KMS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,11 @@ jobs:
     env:
       CMAKE: cmake.exe
       WIX: ${{ github.workspace }}\wix\
+      JsignJar: ${{ github.workspace }}\jsign.jar
+      SigningStoreType: GOOGLECLOUD
+      SigningKeyStore: ${{ secrets.GOOGLE_CLOUD_KMS_KEYRING }}
+      SigningStoreKeyName: ${{ secrets.GOOGLE_CLOUD_KMS_KEY }}
+      SigningCertificateFile: ${{ github.workspace }}/certificate.pem
 
     name: 'openvpn-build'
     runs-on: windows-latest
@@ -43,6 +48,18 @@ jobs:
       - name: Setup MSVC prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        if: ${{ env.SigningKeyStore != '' }}
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Download Jsign
+        if: ${{ env.SigningKeyStore != '' }}
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar" -OutFile jsign.jar
+
       - name: Install Wix 3.14.1
         run: |
           Invoke-WebRequest -Uri "https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip" -OutFile wix.zip
@@ -59,8 +76,29 @@ jobs:
           $version_m4 -replace '^define\(\[PRODUCT_CODE\], \[\{(?<ProductCode>.*)\}]\)', "define([PRODUCT_CODE], [{${NewProductCode}}])" `
             -replace '^define\(\[PRODUCT_VERSION\], \[(.*?)\]\)', "define([PRODUCT_VERSION], [${NewProductVersion}])" | Out-File -Encoding ASCII version.m4
 
+      - name: Authenticate to Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        if: ${{ env.SigningKeyStore != '' }}
+        with:
+          create_credentials_file: false
+          token_format: 'access_token'
+          workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WIP }}
+          service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
+          access_token_lifetime: '600s'
+
+      - name: Build and Sign
+        working-directory: windows-msi
+        env:
+           SigningStorePass: ${{ steps.auth.outputs.access_token }}
+        if: ${{ env.SigningKeyStore != '' }}
+        run: |
+          echo "${{ secrets.SIGNING_CERTIFICATE }}" >${{ github.workspace }}/certificate.pem
+          ./build-and-package.ps1 -sign -arch ${{ matrix.arch }}
+
       - name: Build
         working-directory: windows-msi
+        if: ${{ env.SigningKeyStore == '' }}
         run: |
           ./build-and-package.ps1 -arch ${{ matrix.arch }}
 

--- a/release/vars.example
+++ b/release/vars.example
@@ -16,8 +16,6 @@ GPG_KEY_ID="F554A3687412CFFEBDEFE0A312F5F7B42F2B01E7"
 GPG_OPTS="--no-default-keyring --keyring ~/.gnupg-security@openvpn.net/pubring.kbx"
 GIT_AUTHOR="Yuriy Darnobyt <yuriy.darnobyt@openvpn.net>"
 
-WINDOWS_SIGNING_KEY_FP="31DA19926259519C9EA312C71935B13C33FC6E7E"
-
 # Sometimes we release MSI build only with new INSTALLER_BUILD version
 # It does not require to tag and push OpenVPN sources again
 # It also does not require to re-build linux packages

--- a/windows-msi/sign-binaries.bat
+++ b/windows-msi/sign-binaries.bat
@@ -1,2 +1,0 @@
-rem Sign all executables and libraries
-%SignScript%

--- a/windows-msi/sign-msi.bat
+++ b/windows-msi/sign-msi.bat
@@ -2,14 +2,18 @@
 
 rem This script digitally signs MSI packages.
 rem
-rem Set `%ManifestCertificateThumbprint%` to SHA-1 thumbprint of your code signing
-rem certificate. This thumbprint is used only to locate the certificate in user
-rem certificate store. The signing and timestamping will use SHA-256 hashes.
-rem
 rem Set `%ManifestTimestampRFC3161Url%` to URL of your code signing cerificate provider's
 rem RFC3161-compliant web service.
 rem
 rem Run this script after `cscript build.wsf msi` and before
 rem `cscript build.wsf exe`.
 
-signtool.exe sign /sha1 "%ManifestCertificateThumbprint%" /fd sha256 /tr "%ManifestTimestampRFC3161Url%" /td sha256 /d "OpenVPN Setup" image\*.msi
+java -jar %JsignJar%^
+    --storetype %SigningStoreType%^
+    --storepass %SigningStorePass%^
+    --keystore %SigningKeyStore%^
+    --alias %SigningStoreKeyName%^
+    --certfile %SigningCertificateFile%^
+    --tsmode RFC3161^
+    --tsaurl %ManifestTimestampRFC3161Url%^
+ image\*.msi

--- a/windows-msi/sign-openvpn.bat
+++ b/windows-msi/sign-openvpn.bat
@@ -2,40 +2,25 @@
 
 rem This script digitally signs openvpn-build outputs.
 rem
-rem Set `%ManifestCertificateThumbprint%` to SHA-1 thumbprint of your code signing
-rem certificate. This thumbprint is used only to locate the certificate in user
-rem certificate store. The signing and timestamping will use SHA-256 hashes.
-rem
 rem Set `%ManifestTimestampRFC3161Url%` to URL of your code signing cerificate provider's
 rem RFC3161-compliant web service.
 rem
 rem Run this script before packaging.
 
-signtool.exe sign /sha1 "%ManifestCertificateThumbprint%" /fd sha256 /tr "%ManifestTimestampRFC3161Url%" /td sha256^
- ..\src\openvpn\out\build\win-amd64-release\Release\*.exe^
- ..\src\openvpn\out\build\win-amd64-release\Release\*.dll^
- ..\src\openvpn\out\build\win-amd64-release\src\openvpnmsica\Release\*.exe^
- ..\src\openvpn\out\build\win-amd64-release\src\openvpnserv\Release\*.exe^
- ..\src\openvpn\out\build\win-amd64-release\src\tapctl\Release\*.exe^
- ..\src\openvpn\out\build\win-arm64-release\Release\*.exe^
- ..\src\openvpn\out\build\win-arm64-release\Release\*.dll^
- ..\src\openvpn\out\build\win-arm64-release\src\openvpnmsica\Release\*.exe^
- ..\src\openvpn\out\build\win-arm64-release\src\openvpnserv\Release\*.exe^
- ..\src\openvpn\out\build\win-arm64-release\src\tapctl\Release\*.exe^
- ..\src\openvpn\out\build\win-x86-release\Release\*.exe^
- ..\src\openvpn\out\build\win-x86-release\Release\*.dll^
- ..\src\openvpn\out\build\win-x86-release\src\openvpnmsica\Release\*.exe^
- ..\src\openvpn\out\build\win-x86-release\src\openvpnserv\Release\*.exe^
- ..\src\openvpn\out\build\win-x86-release\src\tapctl\Release\*.exe^
- ..\src\openvpn\out\build\win-amd64-release\vcpkg_installed\x64-windows-ovpn\tools\openssl\openssl.exe^
- ..\src\openvpn\out\build\win-amd64-release\vcpkg_installed\x64-windows-ovpn\bin\*.dll^
- ..\src\openvpn\out\build\win-arm64-release\vcpkg_installed\arm64-windows-ovpn\tools\openssl\openssl.exe^
- ..\src\openvpn\out\build\win-arm64-release\vcpkg_installed\arm64-windows-ovpn\bin\*.dll^
- ..\src\openvpn\out\build\win-x86-release\vcpkg_installed\x86-windows-ovpn\tools\openssl\openssl.exe^
- ..\src\openvpn\out\build\win-x86-release\vcpkg_installed\x86-windows-ovpn\bin\*.dll^
- ..\src\openvpn-gui\out\build\x64\Release\openvpn-gui.exe^
- ..\src\openvpn-gui\out\build\x64\Release\*.dll^
- ..\src\openvpn-gui\out\build\arm64\Release\openvpn-gui.exe^
- ..\src\openvpn-gui\out\build\arm64\Release\*.dll^
- ..\src\openvpn-gui\out\build\x86\Release\openvpn-gui.exe^
- ..\src\openvpn-gui\out\build\x86\Release\*.dll
+java -jar %JsignJar%^
+    --storetype %SigningStoreType%^
+    --storepass %SigningStorePass%^
+    --keystore %SigningKeyStore%^
+    --alias %SigningStoreKeyName%^
+    --certfile %SigningCertificateFile%^
+    --tsmode RFC3161^
+    --tsaurl %ManifestTimestampRFC3161Url%^
+ ..\src\openvpn\out\build\win-%SignArch%-release\Release\openvpn.exe^
+ ..\src\openvpn\out\build\win-%SignArch%-release\Release\lib*.dll^
+ ..\src\openvpn\out\build\win-%SignArch%-release\src\openvpnmsica\Release\*.dll^
+ ..\src\openvpn\out\build\win-%SignArch%-release\src\openvpnserv\Release\*.exe^
+ ..\src\openvpn\out\build\win-%SignArch%-release\src\tapctl\Release\*.exe^
+ ..\src\openvpn\out\build\win-%SignArch%-release\vcpkg_installed\%SignArchAlt%-windows-ovpn\tools\openssl\openssl.exe^
+ ..\src\openvpn\out\build\win-%SignArch%-release\vcpkg_installed\%SignArchAlt%-windows-ovpn\bin\*.dll^
+ ..\src\openvpn-gui\out\build\%SignArchAlt%\Release\openvpn-gui.exe^
+ ..\src\openvpn-gui\out\build\%SignArchAlt%\Release\*.dll


### PR DESCRIPTION
The goal of this switch is to save costs (only paying for a key in KMS instead of a full running hardware HSM), increase
flexibility (by being able to authenticate via Identity Federation from e.g. running AWS node or GHA runner), without reducing security (key is still stored in hardware HSM in backend, non-exportable).

- windows-msi: Switch signing to use jsign.jar instead of signtool to allow more flexibility in key stores.
- windows-msi: Switch sign-openvpn.bat to only sign one architecture. (Cleanup)
- windows-msi: Fix sign-openvpn.bat to sign openvpnmsica.dll instead of non-existant openvpnmsica.exe. (Bugfix)
- windows-msi: Fix sign-openvpn.bat to not sign unit tests executables and cmocka.dll. (Cleanup)
- windows-msi: Remove sign-binaries.bat intermediate script. Didn't seem to serve any purpose anymore. (Cleanup)
- release: Remove AWS CloudHSM support and add GoogleCloud KMS instead. Adapt to changes in windows-msi.
- .github: Implement signing of snapshot builds.