### PR TITLE
Renovate: Also check other repositories

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   renovate:
+    if: github.repository_owner == 'OpenVPN'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,4 +17,10 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: debug
-          RENOVATE_REPOSITORIES: "[\"${{ github.repository }}\"]"
+          RENOVATE_REPOSITORIES: >-
+            ${{ github.repository_owner }}/openvpn-build,
+            ${{ github.repository_owner }}/openvpn,
+            ${{ github.repository_owner }}/openvpn3
+          RENOVATE_IGNORE_PRESETS: >-
+            local>openvpntechnologies/ops-sec-renovate,
+            local>openvpntechnologies/core-team-renovate


### PR DESCRIPTION
- openvpn3 already has a renovate config which is usually handled by a differente renovate instance, but it is still useful to get PR builds for this in GitHub to verify the GHA updates directly.
- openvpn doesn't have renovate, yet, so we need to do onboarding first. See https://gerrit.openvpn.net/c/openvpn/+/722