### PR TITLE
GHA: Fix building Debian packages on Ubuntu 24.04 runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
     name: Run t_client tests on AWS
     needs: msvc
     concurrency: aws_tclient_tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'openvpn/openvpn-build' && github.event_name != 'pull_request' }}
     env:
       AWS_REGION : "eu-west-1"
@@ -134,7 +134,7 @@ jobs:
   upload_msis:
     needs: run_tclient_tests
     name: upload-msis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' && github.repository == 'openvpn/openvpn-build' }}
 
     steps:
@@ -168,7 +168,7 @@ jobs:
 
   debian:
     name: Build Debian packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CHROOT_CONF: chroots/chroot.d.tar
       OPENVPN_CURRENT_TAG: HEAD
@@ -186,7 +186,7 @@ jobs:
         run: |
           sudo apt-get update
           # for sbuild
-          sudo apt-get install -y sbuild git quilt debhelper dkms
+          sudo apt-get install -y sbuild git quilt debhelper dkms dh-dkms
           # for ./configure && make dist
           sudo apt-get install -y autoconf automake libcap-ng-dev libssl-dev python3-docutils
 
@@ -244,9 +244,12 @@ jobs:
         run: |
           scripts/prepare-all.sh
 
+      # includes work-around for https://github.com/actions/runner-images/issues/9932
+      # (sg and newgrp require password to run)
       - name: Build packages
         working-directory: debian-sbuild
         run: |
+          sudo gpasswd -r sbuild
           sg sbuild ./scripts/build-all.sh
 
       - name: Archive packages


### PR DESCRIPTION
Requires installing dh-dkms since dkms support moved to that package.

Require a work-around for running sg which will fail by default on Ubuntu 24.04 runners.

Also hard-code the Ubuntu version. Renovate will tell us when there is a new runner available and we can switch at our own pace.