### PR TITLE
GHA: Use a self-hosted runner for t_client tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,8 +122,7 @@ jobs:
   run_tclient_tests:
     name: Run t_client tests on AWS
     needs: msvc
-    concurrency: aws_tclient_tests
-    runs-on: ubuntu-24.04
+    runs-on: msitest
     if: ${{ github.repository == 'openvpn/openvpn-build' && github.event_name != 'pull_request' }}
     env:
       AWS_REGION : "eu-west-1"
@@ -132,8 +131,6 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
         with:
-          role-to-assume: arn:aws:iam::217307881341:role/GitHubActions
-          role-session-name: githubactions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Clone openvpn-windows-test repo
@@ -148,6 +145,10 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY_FOR_TCLIENT_HOST }}
           known_hosts: unnecessary
+
+      - name: Cleanup old artifacts
+        run:
+          rm -fr msi
 
       - name: Get artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8


### PR DESCRIPTION
This allows us to remove the concurrency setting
so we can wait longer for an available runner.