### PR TITLE
renovate: ensure correct dco-win versioning in master and release/2.6…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,18 @@
             "matchPackageNames": [
                 "OpenVPN/ovpn-dco-win"
             ],
-            "allowedVersions": "2.x"
+            "allowedVersions": "2.x",
+            "matchBaseBranches": ["master"]
+        },
+        {
+            "matchDatasources": [
+                "github-releases"
+            ],
+            "matchPackageNames": [
+                "OpenVPN/ovpn-dco-win"
+            ],
+            "allowedVersions": "1.x",
+            "matchBaseBranches": ["release/2.6"]
         }
     ],
     "customManagers": [


### PR DESCRIPTION
… branches

It seems that renovate uses config from default branch, so we have to ensure versioning for release branch here.