### PR TITLE
msi: use loose versioning for openvpnserv2 in Renovate

### DIFF
--- a/windows-msi/version.m4
+++ b/windows-msi/version.m4
@@ -21,7 +21,7 @@ dnl renovate: datasource=github-releases depName=OpenVPN/ovpn-dco-win
 define([PRODUCT_OVPN_DCO_VERSION],     [2.5.6])
 
 dnl OpenVPNServ2.exe binary
-dnl renovate: datasource=github-releases depName=OpenVPN/openvpnserv2
+dnl renovate: datasource=github-releases depName=OpenVPN/openvpnserv2 versioning=loose
 define([OVPNSERV2_VERSION], [1.4.0.1])
 
 dnl Easy-RSA binaries:


### PR DESCRIPTION
By default, Renovate uses semantic versioning, which assumes versions follow the format X.Y.Z. However, openvpnserv2 uses 4-part versions like 1.4.0.1 and 2.0.0.0.

This commit tells Renovate to use versioning=loose, which accepts versions with any number of dot-separated segments and compares them correctly.