### PR TITLE
GHA: reintroduce manual vcpkg caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
       SigningKeyStore: ${{ secrets.GOOGLE_CLOUD_KMS_KEYRING }}
       SigningStoreKeyName: ${{ secrets.GOOGLE_CLOUD_KMS_KEY }}
       SigningCertificateFile: ${{ github.workspace }}/certificate.pem
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
 
     name: 'openvpn-build'
     runs-on: windows-latest
@@ -33,7 +34,16 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Restore from cache and install vcpkg
+      - name: Restore vcpkg cache
+        id: vcpkg-restore
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: "${{ github.workspace }}/vcpkg_cache"
+          key: vcpkg-${{ matrix.arch }}-${{ hashFiles('**/src/openvpn/contrib/vcpkg-manifests/windows/vcpkg.json', '**/src/vcpkg/ports/openssl/vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.arch }}-
+
+      - name: Install vcpkg
         uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
         with:
           vcpkgDirectory: '${{ github.workspace }}/src/vcpkg'
@@ -119,6 +129,14 @@ jobs:
         with:
           name: openvpn-master-${{ env.DATETIME }}-${{ env.OPENVPN_COMMIT }}-${{ matrix.arch }}
           path: ${{ github.workspace }}\windows-msi\image\*-${{ matrix.arch }}.msi
+
+      - name: Save vcpkg cache
+        if: steps.vcpkg-restore.outputs.cache-hit != 'true'
+        id: vcpkg-save
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: "${{ github.workspace }}/vcpkg_cache"
+          key: ${{ steps.vcpkg-restore.outputs.cache-primary-key }}
 
   run_tclient_tests:
     name: Run t_client tests on AWS


### PR DESCRIPTION
The built-in mechanism is broken due to API changes on Github side. Doesn't seem like they intend to fix it.