### PR TITLE
msi: set log directory permission for service account only when service

### DIFF
--- a/windows-msi/msi.wxs
+++ b/windows-msi/msi.wxs
@@ -1223,7 +1223,6 @@
             <ComponentRef Id="bin.tapctl.exe"/>
             <ComponentRef Id="config.README.txt"/>
             <ComponentRef Id="log.README.txt"/>
-            <ComponentRef Id="LOGDIR.permissions"/>
             <ComponentRef Id="res.ovpn.ico"/>
             <ComponentRef Id="reg.path"/>
             <ComponentRef Id="reg.bin_dir"/>
@@ -1284,6 +1283,7 @@
                 <ComponentRef Id="bin.openvpn_plap_uninstall.reg"/>
                 <ComponentRef Id="config_auto.README.txt"/>
                 <ComponentRef Id="reg.autostart_config_dir"/>
+                <ComponentRef Id="LOGDIR.permissions"/>
 
                 <Feature
                     Id="OpenVPN.PLAP.Register"


### PR DESCRIPTION
is installed

When service is not installed, its viirtual service account is not created and permission setting fails.

GitHub: #963