### PR TITLE
GHA: Switch to windows-2022 for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
 
     name: 'openvpn-build'
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Checkout openvpn-build


### PR DESCRIPTION
windows-latest/windows-2025 now uses VC 2026 which breaks our build due to CMake being hard-coded to VC 2022.