### PR TITLE
renovate: Drop PRs for release/2.6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "baseBranchPatterns": [ "master", "release/2.6", "release/2.7" ],
+    "baseBranchPatterns": [ "master", "release/2.7" ],
     "prConcurrentLimit": 15,
     "packageRules": [
         {


### PR DESCRIPTION
No further binary releases are planned for 2.6. Only sources. So we do not need all this machinery.